### PR TITLE
Science tweaks (In progress!)

### DIFF
--- a/GameData/KerbalismConfig/System/Science/NewExperiments.cfg
+++ b/GameData/KerbalismConfig/System/Science/NewExperiments.cfg
@@ -53,6 +53,28 @@ EXPERIMENT_DEFINITION:NEEDS[FeatureScience,RP-0]
 		default = All systems are performing nominally.
     }
 }
+// ============================================================================
+// Supersonic crewed
+// ============================================================================
+//Supersonic flight test
+EXPERIMENT_DEFINITION:NEEDS[FeatureScience,RP-0]
+{
+    id = supersonicReport
+    title = Crewed Supersonic Flight
+    baseValue = 2
+    scienceCap = 2
+    dataScale = 2
+	
+    requireAtmosphere = False
+    situationMask = 12
+    biomeMask = 0
+
+    RESULTS
+    {
+        default = Basic telemetry and operational data from the vessel are recorded. //FIXME
+		default = All systems are performing nominally. //FIXME
+    }
+}
 
 // ============================================================================
 // BioSample

--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
@@ -49,9 +49,9 @@ KERBALISM_EXPERIMENT_VALUES
 		ECCost = 0.0001
 		size = 0.0007875 //3.5 b/s
 		SampleMass = 0 // a file, not a sample
-		value = 10
-		duration = 1800 //30 minutes
-		requirements = SurfaceSpeedMin:343
+		value = 20
+		duration = 7200 //2 hours
+		requirements = SurfaceSpeedMin:343, AltitudeMax:110000
 		ResourceRates = 
 		IncludeExperiment = 
 	}
@@ -185,6 +185,17 @@ KERBALISM_EXPERIMENT_VALUES
 		requirements = 
 		ResourceRates = 
 		IncludeExperiment = 
+	}
+	supersonicReport //Supersonic flight test
+	{
+		ECCost = 0.0
+		size = 0.005
+		SampleMass = 0 // a file, not a sample
+		value = 15
+		duration = 3000 //50 minutes
+		requirements = SurfaceSpeedMin:343, AltitudeMin:10000
+		ResourceRates = 
+		IncludeExperiment = crewReport
 	}
 	capsuleReport // orbital experiments
 	{

--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/Photography.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/Photography.cfg
@@ -38,8 +38,8 @@
 	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/RP0photos1/value$
 	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/RP0photos1/size$
 	@dataScale /= #$baseValue$
-	%situationMask = 20
-	%biomeMask = 20
+	%situationMask = 16
+	%biomeMask = 16
 	KERBALISM_EXPERIMENT
   	{
    		// sample mass in tons. if undefined or 0, the experiment produce a file

--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/crewReport.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/crewReport.cfg
@@ -44,6 +44,46 @@
 }
 
 // ============================================================================
+// Crewed Supersonic flight test
+// ============================================================================
+@PART[*]:HAS[@MODULE[ModuleScienceExperiment]:HAS[#experimentID[RP0telemetry2]]]:NEEDS[FeatureScience,RP-0]:FOR[RP-0-Kerbalism] //FIXME
+{
+	!MODULE[ModuleScienceExperiment]:HAS[#experimentID[RP0telemetry2]]	{}//FIXME
+	MODULE
+	{
+		name = Experiment
+		experiment_id = supersonicReport
+	}
+}
+
+@PART[*]:HAS[@MODULE[Experiment]]:NEEDS[FeatureScience,RP-0]:AFTER[RP-0-Kerbalism]//FIXME
+{
+	@MODULE[Experiment]:HAS[#experiment_id[supersonicReport]]
+	{
+		%ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/supersonicReport/ECCost$
+		%data_rate = #$@KERBALISM_EXPERIMENT_VALUES/supersonicReport/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/supersonicReport/duration$
+		%requires = #$@KERBALISM_EXPERIMENT_VALUES/supersonicReport/requirements$
+		%resources = #$@KERBALISM_EXPERIMENT_VALUES/supersonicReport/ResourceRates$
+		hide_when_unavailable = true
+		%experiment_desc = Supersonic and hypersonic crewed flight test.
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[supersonicReport]]:NEEDS[FeatureScience,RP-0]:AFTER[RP-0-Kerbalism]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/supersonicReport/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/supersonicReport/size$
+	@dataScale /= #$baseValue$
+	KERBALISM_EXPERIMENT
+  	{
+   		// sample mass in tons. if undefined or 0, the experiment produce a file
+    	SampleMass = #$@KERBALISM_EXPERIMENT_VALUES/supersonicReport/SampleMass$
+		IncludeExperiment = #$@KERBALISM_EXPERIMENT_VALUES/supersonicReport/IncludeExperiment$
+  	}
+}
+
+// ============================================================================
 // astronaut report
 // ============================================================================
 @PART[*]:HAS[@MODULE[ModuleScienceExperiment]:HAS[#experimentID[capsuleReport]]]:NEEDS[FeatureScience,RP-0]:FOR[xxxRP1]


### PR DESCRIPTION
Trying to address some of the issues with the very early game science, especially the fact that most of the science gathered in the low atmosphere wouldn't be relevant at the game timeline. The idea is to create a crewed supersonic "report" experiment, that would be pretty much the only science to be gathered in the low atmosphere. I made a placeholder experiment for that, but a couple things I'd like to note:
1. the MM patches are still wrong because I just copy-pasted from the supersonic analysis experiment
2. Is it possible to make an experiment that ignores body multipliers? We were considering killing the flying low multiplier on Earth, but then this experiment would need to get a separate science value. It would be nice to keep it with a sane data value because then we can have the same experiment flying high.

This PR is also removing the flying low situation mask from the film photography experiment, as aerial photos were nothing new in the 50s.

I was also looking into the SCANSat patches, that are currently broken, but didn't figure how to fix that yet.