### PR TITLE
Re-balance corona values based on historical data

### DIFF
--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
@@ -131,10 +131,10 @@ KERBALISM_EXPERIMENT_VALUES
 	RP0photos2 //Corona series of satellites
 	{
 		ECCost = 0.1
-		SampleMass = 0.5
+		SampleMass = 0.1 //first recovery only had about 10kg of film, 100kg per recovery feels excessive
 		size = 50
-		value = 200 //FIXME
-		duration = 63072000 //2 years, program lasted from 1959 to 1972, reduced for balance
+		value = 100 //reduced due to reduced duration
+		duration = 8640000 //100 days, max mission time for corona was about 20 days
 		requirements = OrbitMinInclination:60,OrbitMaxInclination:100,OrbitMaxEccentricity:0.035,AltitudeMax:445000
 		ResourceRates = 
 		IncludeExperiment = 


### PR DESCRIPTION
This is a rework of the corona camera experiment based on research I did, outlined in issue #1344 in rp1.

Total sample mass reduced from 500kg to 100kg, or 20kg per launch. 100kg seems like way too much film. Considering the first return only brought back about 10kg, 20kg seems more accurate. It's hard to get exact numbers on the mass of the film they carried, and the missions varied. In fact, most satellites completed their missions in only a day or two, even though the later ones could stay up for about 20 days. It's hard to imagine a camera that can go through 100kg of film specifically designed to be extra thin and light, in only 24 hours.

Total science return reduced from 200 to 100. This for balance reasons due to the reduced experiment duration.

Total duration reduced from 2 years to 100 days, or 20 days per camera. This is to match the camera's historical mission parameters.

The corona camera is an odd experiment as it currently is, and a lot of it's parameters don't seem to make much sense. Yes, the real thing used about 100 watts. The reason it's such a struggle to power with solar panels is because the real satellite had about 250 kg of batteries. With these changes and those on rp1, the satellites and LVs players create will be much closer to historical data, and the mission profiles will be quite similar as well.