### PR TITLE
Fix animation name for big cameras

### DIFF
--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/Photography.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/Photography.cfg
@@ -62,7 +62,7 @@
 	{
 		name = Experiment
 		experiment_id = RP0photos2
-		anim_deploy = deploy
+		anim_deploy = reconDeploy
 	}
 }
 
@@ -111,7 +111,7 @@
 	{
 		name = Experiment
 		experiment_id = RP0photos3
-		anim_deploy = deploy
+		anim_deploy = reconDeploy
 	}
 }
 
@@ -160,7 +160,7 @@
 	{
 		name = Experiment
 		experiment_id = RP0photos4
-		anim_deploy = deploy
+		anim_deploy = reconDeploy
 	}
 }
 


### PR DESCRIPTION
photo1 is also broken with restock, but since the animation
makes it clear it's not a camera at all, better leave it broken