### PR TITLE
ROCapsules X-20 Moroz Dynasoar support

### DIFF
--- a/GameData/KerbalismConfig/Support/ROCapsules.cfg
+++ b/GameData/KerbalismConfig/Support/ROCapsules.cfg
@@ -213,18 +213,22 @@
 	}
 }
 
-@PART[ROC-DynaBody]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+//Dynasoar
+//Give base dynasoar 35 hours endurance
+@PART[ROC-DynaBody|ROC-DynaCockpitMoroz]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
 {
-	@description ^= :$: Supports a crew of one for up to maximum 35 hours of active operations.
+	@description ^= :$:  Supports a crew of one for up to 35 hours of active operations.
+	@mass -= 0.011
 
 	@MODULE[ModuleFuelTanks]
 	{
 
+		@volume += 65
 		TANK
 		{
 			name = Food
 			amount = 8.5302
-			maxAmount = 8.5302
+			maxAmount = 8.5302	//35 hours
 		}
 
 		TANK
@@ -243,16 +247,9 @@
 
 		TANK
 		{
-			name = Nitrogen
-			amount = 863.1
-			maxAmount = 863.1
-		}
-
-		TANK
-		{
 			name = LithiumHydroxide
-			amount = 1.05
-			maxAmount = 1.05
+			amount = 1.19
+			maxAmount = 1.19
 		}
 
 		TANK
@@ -271,53 +268,63 @@
 	}
 }
 
-@PART[ROC-DynaCabin]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+//Give cabin about 5 days
+@PART[ROC-DynaCabin|ROC-DynaCabinMoroz]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
 {
-	@description ^= :$: Supports a crew of 2 for up to maximum 14 days of active operations.
+	@description ^= :$: Supports a crew of two for up to maximum 5 days of active operations but it will require fuel cells.
+	@mass -= 0.057
 
 	@MODULE[ModuleFuelTanks]
 	{
 		TANK
 		{
 			name = Food
-			amount = 164
-			maxAmount = 164	// 14 days
+			amount = 96.62
+			maxAmount = 96.62	//5 days
 		}
 		TANK
 		{
 			name = Water
-			amount = 8
-			maxAmount = 8	// 1 day
+			amount = 11.62
+			maxAmount = 11.62	//1 day water
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 1184
-			maxAmount = 1184	// 1 day
-		}
-		TANK
-		{
-			name = Nitrogen
-			amount = 5000
-			maxAmount = 5000	//Guess
+			amount = 977.62
+			maxAmount = 977.62	//1 day oxygen
 		}
 		TANK
 		{
 			name = Waste
 			amount = 0
-			maxAmount = 111	// 14 days
+			maxAmount = 65.40
 		}
 		TANK
 		{
 			name = WasteWater
 			amount = 0
-			maxAmount = 138	// 14 days
+			maxAmount = 81.31
 		}
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 29
-			maxAmount = 29	// 14 days
+			amount = 14.8
+			maxAmount = 14.8	//5 days
+		}
+	}
+}
+
+//Nitrogen for cabin pressurization
+@PART[ROC-DynaBody|ROC-DynaButtMoroz]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		TANK
+		{
+			name = Nitrogen
+			amount = 27500
+			maxAmount = 27500	//enough for ~5 EVAs
 		}
 	}
 }
@@ -711,22 +718,22 @@
 		%max_pressure = 0.35
 	}
 }
-@PART[ROC-DynaBody]:NEEDS[ROCapsules,FeatureHabitat]:AFTER[zzzKerbalism]
+@PART[ROC-DynaBody|ROC-DynaCockpitMoroz]:NEEDS[ROCapsules,FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat]
 	{
 		%volume = 2
-		%surface = 10		//guesstimate
-		%max_pressure = 0.55
+		%surface = 14		//guesstimate
+		%max_pressure = 0.55	//pressurized to 0.5 atm
 	}
 }
-@PART[ROC-DynaCabin]:NEEDS[ROCapsules,FeatureHabitat]:AFTER[zzzKerbalism]
+@PART[ROC-DynaCabin|ROC-DynaCabinMoroz]:NEEDS[ROCapsules,FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat]
 	{
 		%volume = 3.50
-		%surface = 5.89		//guesstimate
-		%max_pressure = 0.55
+		%surface = 32		//guesstimate
+		%max_pressure = 0.55	//pressurized to 0.5 atm
 	}
 }
 @PART[ROC-LEMAscent]:NEEDS[ROCapsules,FeatureHabitat]:AFTER[zzzKerbalism]
@@ -818,7 +825,7 @@
 // crew experiments
 
 @PART[ROC-MercuryCM|ROC-MercuryCMBDB|ROC-VostokCapsule]:NEEDS[ROCapsules,FeatureScience,RP-0]:BEFORE[RP-0-Kerbalism] { %capsuleTier = Basic }
-@PART[ROC-GeminiCM|ROC-GeminiCMBDB|ROC-D2MissionModule1|ROC-VoskhodCapsule|ROC-DynaBody]:NEEDS[ROCapsules,FeatureScience,RP-0]:BEFORE[RP-0-Kerbalism] { %capsuleTier = SecondGen }
+@PART[ROC-GeminiCM|ROC-GeminiCMBDB|ROC-D2MissionModule1|ROC-VoskhodCapsule|ROC-DynaBody|ROC-DynaCockpitMoroz]:NEEDS[ROCapsules,FeatureScience,RP-0]:BEFORE[RP-0-Kerbalism] { %capsuleTier = SecondGen }
 @PART[ROC-ApolloCM|ROC-D2MissionModule2|ROC-ApolloCMBlockIII|ROC-OrionCM]:NEEDS[ROCapsules,FeatureScience,RP-0]:BEFORE[RP-0-Kerbalism] { %capsuleTier = Mature }
 
 // hard drives
@@ -833,7 +840,7 @@
 		sampleCapacity = #$@KERBALISM_HDD_SIZES/mercury/samples$
 	}
 }
-@PART[ROC-GeminiCM|ROC-GeminiCMBDB|ROC-DynaBody|ROC-D2CM|ROC-D2MissionModule1]:NEEDS[ROCapsules,FeatureScience,RP-0]:FOR[RP-0-Kerbalism]
+@PART[ROC-GeminiCM|ROC-GeminiCMBDB|ROC-DynaBody|ROC-DynaCockpitMoroz|ROC-D2CM|ROC-D2MissionModule1]:NEEDS[ROCapsules,FeatureScience,RP-0]:FOR[RP-0-Kerbalism]
 {
 	!MODULE[HardDrive] {}
 	MODULE

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -255,20 +255,8 @@
 }
 
 //Dynasoar
-@PART[ROC-DynaBody]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[ROC-DynaBody|ROC-DynaButtMoroz]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-  %capsuleScrubbers = true
-  %scrubberCapacity = 1.3
-  %capsuleOrigin = US
-
-  @MODULE[ModuleCommand]
-  {
-    @RESOURCE[ElectricCharge]
-    {
-      @rate = 1.900  //Remove Climatization and LS power draw
-    }
-  }
-
   MODULE
   {
     name = ProcessController
@@ -344,8 +332,20 @@
   }
 }
 
-//Dynasoar Cabin
-@PART[ROC-DynaCabin]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+//Remove Climatization and LS power draw
+@PART[ROC-DynaBody|ROC-DynaCockpitMoroz]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+  @MODULE[ModuleCommand]
+  {
+    @RESOURCE[ElectricCharge]
+    {
+      @rate = 1.785  //Remove Climatization and LS power draw
+    }
+  }
+}
+
+//Add scrubbers
+@PART[ROC-DynaBody|ROC-DynaCabin|ROC-DynaCockpitMoroz|ROC-DynaCabinMoroz]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
   %capsuleScrubbers = true
   %scrubberCapacity = 1.3


### PR DESCRIPTION
Kerbalism support for the new ROCapsules Dynasoar. Also revise life support settings.
X-20X was intended to carry 4 passengers and operate for 14 days. However, it also would have been larger than the standard X-20. I have configured the X-20 Dynasoar to hold 2 passengers for 5 days, with capability for longer operations, since it is smaller than the X-20X.

ROC PR: https://github.com/KSP-RO/ROCapsules/pull/110