### PR TITLE
Sspx update

### DIFF
--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -82,7 +82,7 @@
 	@tags ^= :$: comfort:
 }
 
-@PART[sspx-habitation-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-habitation-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -90,9 +90,9 @@
 	MODULE
 	{
 		name = ProcessController
-		resource = _PressureControlOxygen
-		title = O2 Pressure Controller
-		desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -108,9 +108,62 @@
 		%volume = 14.12
 		%surface = 36.1
 	}
+	
+	@description ^= :$: Pre-filled with resources for 90 man-days.(e.g. a crew of three for 30 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 527
+			maxAmount = 527
+		}
+		TANK
+		{
+			name = Water
+			amount = 349
+			maxAmount = 349
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 54000
+			maxAmount = 54000
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 74
+			maxAmount = 74
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 443
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 47
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 2300
+			maxAmount = 2300
+		}
+	}
 }
 
-@PART[sspx-utility-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-utility-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -118,9 +171,9 @@
 	MODULE
 	{
 		name = ProcessController
-		resource = _PressureControlOxygen
-		title = O2 Pressure Controller
-		desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -136,6 +189,16 @@
 		%volume = 2.28
 		%surface = 36
 	}
+	
+		@MODULE[ModuleFuelTanks]
+	{
+		TANK
+		{
+			name = Nitrogen
+			amount = 2000.0
+			maxAmount = 2000.0
+		}
+	}
 
 }
 
@@ -147,9 +210,9 @@
 	MODULE
 	{
 		name = ProcessController
-		resource = _PressureControlOxygen
-		title = O2 Pressure Controller
-		desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -165,6 +228,7 @@
 		%volume = 2.0
 		%surface = 14.5
 	}
+	
 }
 
 @PART[sspx-tube-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -221,7 +285,7 @@
 	}
 }
 
-@PART[sspx-core-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-core-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -247,9 +311,19 @@
 		%volume = 16.0
 		%surface = 60.8
 	}
+	
+		@MODULE[ModuleFuelTanks]
+	{
+		TANK
+		{
+			name = Nitrogen
+			amount = 2000.0
+			maxAmount = 2000.0
+		}
+	}
 }
 
-@PART[sspx-habitation-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-habitation-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -294,9 +368,63 @@
 		%volume = 48.4
 		%surface = 91.3
 	}
+
+	@description ^= :$: Pre-filled with resources for 180 man-days.(e.g. a crew of three for 60 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 1060
+			maxAmount = 1060
+		}
+		TANK
+		{
+			name = Water
+			amount = 700
+			maxAmount = 700
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 108000
+			maxAmount = 108000
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 148
+			maxAmount = 148
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 443
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 47
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 5000
+			maxAmount = 5000
+		}
+	}
+
 }
 
-@PART[sspx-habitation-1875-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-habitation-1875-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -322,9 +450,63 @@
 		%volume = 24.2
 		%surface = 56.4
 	}
+
+	@description ^= :$: Pre-filled with resources for 90 man-days.(e.g. a crew of three for 30 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 527
+			maxAmount = 527
+		}
+		TANK
+		{
+			name = Water
+			amount = 349
+			maxAmount = 349
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 54000
+			maxAmount = 54000
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 74
+			maxAmount = 74
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 443
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 47
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 2300
+			maxAmount = 2300
+		}
+	}
+
 }
 
-@PART[sspx-utility-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-utility-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -350,9 +532,21 @@
 		%volume = 21.0
 		%surface = 71.5
 	}
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 2000
+			maxAmount = 2000
+		}
+	}
+
 }
 
-@PART[sspx-science-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-science-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -377,6 +571,17 @@
 	{	
 		%volume = 21.0
 		%surface = 71.5
+	}
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 2000
+			maxAmount = 2000
+		}
 	}
 }
 
@@ -479,7 +684,7 @@
 	}
 }
 
-@PART[sspx-core-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-core-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -505,9 +710,20 @@
 		%volume = 49.3
 		%surface = 83.74
 	}
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 2000
+			maxAmount = 2000
+		}
+	}
 }
 
-@PART[sspx-habitation-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-habitation-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -518,6 +734,17 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+		
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -552,9 +779,57 @@
 		%volume = 83.0
 		%surface = 131.1
 	}
+
+	@description ^= :$: Pre-filled with resources for 180 man-days.(e.g. a crew of three for 60 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 1060
+			maxAmount = 1060
+		}
+		TANK
+		{
+			name = Water
+			amount = 175
+			maxAmount = 175
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 108000
+			maxAmount = 108000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 886
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 94
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 5000
+			maxAmount = 5000
+		}
+	}
+
 }
 
-@PART[sspx-greenhouse-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-greenhouse-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -570,9 +845,65 @@
 		running = true
 	}
 	
+	MODULE
+	{
+		name = ProcessController
+		resource = _algae
+		title = Algae Bioreactor
+		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
 	@MODULE[ProcessController],*
 	{
 		@capacity *= #$/CrewCapacity$
+	}
+	
+		@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 0
+			maxAmount = 1060
+		}
+		TANK
+		{
+			name = Water
+			amount = 0
+			maxAmount = 175
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 0
+			maxAmount = 108000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1000
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 5000
+			maxAmount = 5000
+		}
 	}
 	
 	%MODULE[Habitat]
@@ -589,14 +920,14 @@
 	}
 
 	@tags ^= :$: comfort:
-
+	
 }
 
 @PART[sspx-hub-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
 	%MODULE[Habitat]
 	{	
-		%volume = 51.7
+		%volume = 85.7
 		%surface = 100.9
 	}
 }
@@ -749,7 +1080,7 @@
 	}
 }
 
-@PART[sspx-core-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-core-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -760,6 +1091,17 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+		
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -775,6 +1117,54 @@
 		%volume = 84.9
 		%surface = 132.6
 	}
+	
+	@description ^= :$: Pre-filled with resources for 360 man-days.(e.g. a crew of four for 90 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 2200
+			maxAmount = 2200
+		}
+		TANK
+		{
+			name = Water
+			amount = 350
+			maxAmount = 350
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 216000
+			maxAmount = 216000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1773
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 190
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+	
 }
 
 @PART[sspx-cupola-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -814,7 +1204,7 @@
 	@tags ^= :$: comfort:
 }
 
-@PART[sspx-habitation-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-habitation-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -825,6 +1215,17 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+		
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -848,9 +1249,56 @@
 		bonus = exercise
 	}
 	@tags ^= :$: comfort:
+
+	@description ^= :$: Pre-filled with resources for 540 man-days.(e.g. a crew of six for 90 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 3160
+			maxAmount = 3160
+		}
+		TANK
+		{
+			name = Water
+			amount = 525
+			maxAmount = 525
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 325000
+			maxAmount = 325000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 2700
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 283
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 14000
+			maxAmount = 14000
+		}
+	}
 }
 
-@PART[sspx-habitation-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-habitation-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -861,6 +1309,17 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+		
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -884,9 +1343,57 @@
 		bonus = exercise
 	}
 	@tags ^= :$: comfort:
+
+	@description ^= :$: Pre-filled with resources for 360 man-days.(e.g. a crew of four for 90 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 2200
+			maxAmount = 2200
+		}
+		TANK
+		{
+			name = Water
+			amount = 350
+			maxAmount = 350
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 216000
+			maxAmount = 216000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1773
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 190
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+
 }
 
-@PART[sspx-habitation-375-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-habitation-375-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -897,6 +1404,17 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+		
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -920,9 +1438,57 @@
 		bonus = exercise
 	}
 	@tags ^= :$: comfort:
+
+	@description ^= :$: Pre-filled with resources for 360 man-days.(e.g. a crew of four for 90 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 2200
+			maxAmount = 2200
+		}
+		TANK
+		{
+			name = Water
+			amount = 350
+			maxAmount = 350
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 216000
+			maxAmount = 216000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1773
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 190
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+
 }
 
-@PART[sspx-greenhouse-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-greenhouse-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -938,6 +1504,17 @@
 		running = true
 	}
 	
+	MODULE
+	{
+		name = ProcessController
+		resource = _algae
+		title = Greenhouse
+		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
 	@MODULE[ProcessController],*
 	{
 		@capacity *= #$/CrewCapacity$
@@ -947,6 +1524,51 @@
 	{	
 		%volume = 83.2
 		%surface = 137.3
+	}
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 0
+			maxAmount = 1060
+		}
+		TANK
+		{
+			name = Water
+			amount = 0
+			maxAmount = 175
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 0
+			maxAmount = 108000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1000
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 5000
+			maxAmount = 5000
+		}
 	}
 	
 		MODULE
@@ -957,10 +1579,10 @@
 	}
 
 	@tags ^= :$: comfort:
-	
+
 }
 
-@PART[sspx-aquaculture-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-aquaculture-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -976,29 +1598,12 @@
 		running = true
 	}
 	
-	@MODULE[ProcessController],*
-	{
-		@capacity *= #$/CrewCapacity$
-	}
-	
-	%MODULE[Habitat]
-	{	
-		%volume = 83.2
-		%surface = 137.3
-	}
-}
-
-@PART[sspx-lab-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
-{
-	%capsuleScrubbers = true
-	%scrubberCapacity = 1.67
-	
 	MODULE
 	{
 		name = ProcessController
-		resource = _PressureControl
-		title = N2 Pressure Controller
-		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		resource = _algae
+		title = Algae Bioreactor
+		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -1014,6 +1619,139 @@
 		%volume = 83.2
 		%surface = 137.3
 	}
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 0
+			maxAmount = 1060
+		}
+		TANK
+		{
+			name = Water
+			amount = 0
+			maxAmount = 175
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 0
+			maxAmount = 108000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1000
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 5000
+			maxAmount = 5000
+		}
+	}
+
+}
+
+@PART[sspx-lab-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	%MODULE[Habitat]
+	{	
+		%volume = 83.2
+		%surface = 137.3
+	}
+
+	@description ^= :$: Pre-filled with resources for 180 man-days (e.g. a crew of three for 60 days). 
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 1060
+			maxAmount = 1060
+		}
+		TANK
+		{
+			name = Water
+			amount = 175
+			maxAmount = 175
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 108000
+			maxAmount = 108000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 886
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 94
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 5000
+			maxAmount = 5000
+		}
+	}
+
 }
 
 @PART[sspx-tube-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -1051,7 +1789,7 @@
 //	=================================================================
 
 
-@PART[sspx-core-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-core-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 
 	%capsuleScrubbers = true
@@ -1067,6 +1805,17 @@
 		toggle = true
 		running = true
 	}
+		
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
 	
 	@MODULE[ProcessController],*
 	{
@@ -1078,6 +1827,54 @@
 		%volume = 210.0
 		%surface = 251.6
 	}
+
+	@description ^= :$: Pre-filled with resources for 900 man-days.(e.g. a crew of five for 180 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 5265
+			maxAmount = 5265
+		}
+		TANK
+		{
+			name = Water
+			amount = 218
+			maxAmount = 218
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 540000
+			maxAmount = 540000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1100
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 470
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 10000
+			maxAmount = 10000
+		}
+	}
+
 }
 
 @PART[sspx-dome-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -1097,6 +1894,7 @@
 	}
 
 	@tags ^= :$: comfort:
+
 }
 
 @PART[sspx-dome-cupola-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -1134,9 +1932,10 @@
 	}
 
 	@tags ^= :$: comfort:
+
 }
 
-@PART[sspx-dome-greenhouse-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-dome-greenhouse-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -1152,6 +1951,17 @@
 		running = true
 	}
 	
+	MODULE
+	{
+		name = ProcessController
+		resource = _algae
+		title = Greenhouse
+		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
 	@MODULE[ProcessController],*
 	{
 		@capacity *= #$/CrewCapacity$
@@ -1161,6 +1971,51 @@
 	{	
 		%volume = 190.8
 		%surface = 190.8
+	}
+	
+		@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 0
+			maxAmount = 1060
+		}
+		TANK
+		{
+			name = Water
+			amount = 0
+			maxAmount = 175
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 0
+			maxAmount = 108000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1000
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 5000
+			maxAmount = 5000
+		}
 	}
 	
 	MODULE
@@ -1178,9 +2033,10 @@
 	}
 
 	@tags ^= :$: comfort:
+
 }
 
-@PART[sspx-dome-habitation-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-dome-habitation-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -1191,6 +2047,17 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+		
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -1221,9 +2088,57 @@
 		bonus = exercise
 	}
 	@tags ^= :$: comfort:
+
+	@description ^= :$: Pre-filled with resources for 120 man-days.(e.g. a crew of four for 30 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 702
+			maxAmount = 702
+		}
+		TANK
+		{
+			name = Water
+			amount = 116.25
+			maxAmount = 116.25
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 72000
+			maxAmount = 72000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 150
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 63
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 3125
+			maxAmount = 3125
+		}
+	}
+
 }
 
-@PART[sspx-habitation-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-habitation-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -1234,6 +2149,17 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+		
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -1257,9 +2183,57 @@
 		bonus = exercise
 	}
 	@tags ^= :$: comfort:
+
+	@description ^= :$: Pre-filled with resources for 9000 man-days.(e.g. a crew of ten for 900 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 52700
+			maxAmount = 5270
+		}
+		TANK
+		{
+			name = Water
+			amount = 349
+			maxAmount = 349
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 54000
+			maxAmount = 54000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 110
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 47
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 2300
+			maxAmount = 2300
+		}
+	}
+
 }
 
-@PART[sspx-habitation-5-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-habitation-5-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -1270,6 +2244,17 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+		
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		desc = Filters impurities out of <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -1293,9 +2278,56 @@
 		bonus = exercise
 	}
 	@tags ^= :$: comfort:
+
+	description ^= :$: Pre-filled with resources for 540 man-days.(e.g. a crew of six for 90 days).
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 3160
+			maxAmount = 3160
+		}
+		TANK
+		{
+			name = Water
+			amount = 525
+			maxAmount = 525
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 324000
+			maxAmount = 324000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 650
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 283
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 11000
+			maxAmount = 11000
+		}
+	}
 }
 
-@PART[sspx-greenhouse-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-greenhouse-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -1306,6 +2338,17 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _algae
+		title = Algae Bioreactor
+		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
 		capacity = 1.67
 		toggle = true
 		running = true
@@ -1322,6 +2365,51 @@
 		%surface = 353.4
 	}
 	
+		@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Food
+			amount = 0
+			maxAmount = 1060
+		}
+		TANK
+		{
+			name = Water
+			amount = 0
+			maxAmount = 175
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 0
+			maxAmount = 108000
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 1000
+		}
+
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = 10000
+		}
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 5000
+			maxAmount = 5000
+		}
+	}
+	
 		MODULE
 	{
 		name = Comfort
@@ -1336,9 +2424,10 @@
 	}
 
 	@tags ^= :$: comfort:
+
 }
 
-@PART[sspx-lab-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[sspx-lab-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,RealFuels]:AFTER[RealismOverhaul]
 {
 	%capsuleScrubbers = true
 	%scrubberCapacity = 1.67
@@ -1364,6 +2453,7 @@
 		%volume = 150.0
 		%surface = 251.0
 	}
+
 }
 
 @PART[sspx-logistics-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -1469,7 +2559,7 @@
 	
 }
 
-@PART[sspx-inflatable-hab-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-inflatable-hab-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1477,10 +2567,21 @@
 		%surface = 125.0
 	}
 
-	!MODULE[ModuleDeployableHabitat] {} 
+	!MODULE[ModuleDeployableHabitat] {}
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 80000
+			maxAmount = 80000
+		}
+	}
 }
 
-@PART[sspx-inflatable-hab-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-inflatable-hab-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1489,9 +2590,20 @@
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 30000
+			maxAmount = 30000
+		}
+	}
 }
 
-@PART[sspx-inflatable-hab-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-inflatable-hab-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1500,9 +2612,21 @@
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
+
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 30000
+			maxAmount = 30000
+		}
+	}
 }
 
-@PART[sspx-inflatable-centrifuge-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-inflatable-centrifuge-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1527,9 +2651,21 @@
 	}
 
 	!MODULE[ModuleDeployableCentrifuge] {} 
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 120000
+			maxAmount = 120000
+		}
+	}
+
 }
 
-@PART[sspx-inflatable-centrifuge-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-inflatable-centrifuge-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1553,9 +2689,20 @@
 	}
 
 	!MODULE[ModuleDeployableCentrifuge] {}
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 60000
+			maxAmount = 60000
+		}
+	}
 }
 
-@PART[sspx-inflatable-hab-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-inflatable-hab-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1564,10 +2711,22 @@
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 700000
+			maxAmount = 700000
+		}
+	}
+
 }
 
 
-@PART[sspx-inflatable-hab-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-inflatable-hab-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1575,10 +2734,22 @@
 		%surface = 320.0
 	}
 
-	!MODULE[ModuleDeployableHabitat] {} 
+	!MODULE[ModuleDeployableHabitat] {}
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 300000
+			maxAmount = 300000
+		}
+	}
+
 }
 
-@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1603,9 +2774,21 @@
 	}
 
 	!MODULE[ModuleDeployableCentrifuge] {}
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 300000
+			maxAmount = 300000
+		}
+	}
+
 }
 
-@PART[sspx-expandable-centrifuge-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-expandable-centrifuge-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1630,9 +2813,21 @@
 	}
 
 	!MODULE[ModuleDeployableCentrifuge] {}
+	
+		@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 1000000
+			maxAmount = 1000000
+		}
+	}
+
 }
 
-@PART[sspx-expandable-centrifuge-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-expandable-centrifuge-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1657,9 +2852,21 @@
 	}
 
 	!MODULE[ModuleDeployableCentrifuge] {}
+	
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 400000
+			maxAmount = 400000
+		}
+	}
+
 }
 
-@PART[sspx-expandable-centrifuge-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+@PART[sspx-expandable-centrifuge-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat,RealFuels]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
@@ -1684,6 +2891,18 @@
 	}
 
 	!MODULE[ModuleDeployableCentrifuge] {}
+
+	@MODULE[ModuleFuelTanks]
+	{
+
+		TANK
+		{
+			name = Nitrogen
+			amount = 1500000
+			maxAmount = 1500000
+		}
+	}
+
 }
 
 //	=================================================================

--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -2794,6 +2794,7 @@
 	{	
 		%volume = 922
 		%surface = 1411
+		%inflatableUsingRigidWalls = True
 	}
 
 	MODULE
@@ -2833,6 +2834,7 @@
 	{	
 		%volume = 350
 		%surface = 650
+		%inflatableUsingRigidWalls = True
 	}
 
 	MODULE
@@ -2872,6 +2874,7 @@
 	{	
 		%volume = 1300
 		%surface = 5900
+		%inflatableUsingRigidWalls = True
 	}
 
 	MODULE

--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -1,5 +1,5 @@
 //	=================================================================
-//	3.05m (MOL Size) Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
+//	2.25m Modules (Rassvet, Pirs, Prichal, various chambers and adapters, MOL) - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
 //	sspx-core-125-1				PTD-8R 'Pier' Station Core
 //	sspx-cupola-125-1			PTD-C 'Porthole' Observation Window
@@ -34,8 +34,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 24.4
-		%surface = 47.7
+		%volume = 7.7
+		%surface = 24.1
 	}
 }
 
@@ -43,8 +43,8 @@
 {
 	@MODULE[Habitat]
 	{	
-		%volume = 12.04
-		%surface = 22.53
+		%volume = 3.36
+		%surface = 19.9
 	}
 	
 	MODULE
@@ -53,6 +53,26 @@
 		bonus = panorama
 		desc = The cupola offer a relaxing panoramic view of the void of space.
 	}
+
+	@tags ^= :$: comfort:
+}
+
+@PART[sspx-cupola-greenhouse-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 2.24
+		%surface = 19.9
+	}
+	
+	MODULE
+	{
+		name = Comfort
+		bonus = panorama
+		desc = The cupola offer a relaxing panoramic view of the void of space.
+	}
+
+	// 	Also needs actual greenhouse added
 
 	@tags ^= :$: comfort:
 }
@@ -80,35 +100,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 55.6
-		%surface = 81.18
-	}
-}
-
-@PART[sspx-tube-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
-{
-	@MODULE[Habitat]
-	{	
-		%volume = 69.41
-		%surface = 91.02
-	}
-}
-
-@PART[sspx-tube-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
-{
-	@MODULE[Habitat]
-	{	
-		%volume = 35.8
-		%surface = 46.94
-	}
-}
-
-@PART[sspx-tube-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
-{
-	@MODULE[Habitat]
-	{	
-		%volume = 17.53
-		%surface = 22.99
+		%volume = 14.12
+		%surface = 36.1
 	}
 }
 
@@ -135,8 +128,141 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 23.4
-		%surface = 30.65
+		%volume = 2.28
+		%surface = 36
+	}
+
+}
+
+@PART[sspx-airlock-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControlOxygen
+		title = O2 Pressure Controller
+		desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 2.0
+		%surface = 14.5
+	}
+}
+
+@PART[sspx-tube-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 17.1
+		%surface = 58.8
+	}
+}
+
+@PART[sspx-tube-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 8.55
+		%surface = 33.4
+	}
+}
+
+@PART[sspx-tube-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 5.7
+		%surface = 20.7
+	}
+}
+
+@PART[sspx-hub-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 9.3
+		%surface = 34.6
+	}
+}
+
+
+
+//	=================================================================
+//	3.38m Modules (4.0m max width, Soviet Stations, Mir, ISS Russian Segment) - STOCKALIKE STATION PARTS EXPANSION REDUX
+//
+//
+//	=================================================================
+
+@PART[sspx-attach-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	
+	%MODULE[Habitat]
+	{	
+		%volume = 12.8
+		%surface = 30.5
+	}
+}
+
+@PART[sspx-core-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 16.0
+		%surface = 60.8
+	}
+}
+
+@PART[sspx-habitation-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
 	}
 	
 	MODULE
@@ -156,12 +282,176 @@
 		extra_cost = 0.25
 		extra_mass = 0.05
 	}
-	
 	@tags ^= :$: comfort:
+
+	@MODULE[Habitat]
+	{	
+		%volume = 48.4
+		%surface = 91.3
+	}
+}
+
+@PART[sspx-habitation-1875-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 24.2
+		%surface = 56.4
+	}
+}
+
+@PART[sspx-utility-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 21.0
+		%surface = 71.5
+	}
+}
+
+@PART[sspx-science-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 21.0
+		%surface = 71.5
+	}
+}
+
+@PART[sspx-observation-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 17.1
+		%surface = 25.0
+	}
+	
+}
+
+@PART[sspx-hub-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 63.8
+		%surface = 63.6
+	}
+}
+
+
+@PART[sspx-tube-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 38.5
+		%surface = 67.8
+	}
+}
+
+@PART[sspx-tube-1875-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 29.7
+		%surface = 40.5
+	}
+}
+
+@PART[sspx-tube-1875-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 7.4
+		%surface = 26.9
+	}
+}
+
+@PART[sspx-tube-1875-angled-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 17.0
+		%surface = 55.6
+	}
 }
 
 //	=================================================================
-//	4.15m (Salyut Size) Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
+//	4.5m Modules (ISS American segment, Gateway, Axiom) - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
 //	sspx-attach-25-1
 //	sspx-core-25-1
@@ -179,8 +469,8 @@
 	
 	%MODULE[Habitat]
 	{	
-		%volume = 24.35
-		%surface = 36.99
+		%volume = 21.8
+		%surface = 47.0
 	}
 }
 
@@ -207,8 +497,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 33.6
-		%surface = 46.47
+		%volume = 49.3
+		%surface = 83.74
 	}
 }
 
@@ -233,10 +523,57 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
+	MODULE
+	{
+		name = Comfort
+		bonus = exercise
+		desc = A treadmill designed to permit exercise in zero-g is included. The crew will love it.
+	}
+
+	MODULE:NEEDS[FeatureReliability]
+	{
+		name = Reliability
+		type = Comfort
+		title = Treadmill
+		repair = Engineer
+		mtbf = 36288000
+		extra_cost = 0.25
+		extra_mass = 0.05
+	}
+	@tags ^= :$: comfort:
+
 	@MODULE[Habitat]
 	{	
-		%volume = 81.7
-		%surface = 84.74
+		%volume = 83.0
+		%surface = 131.1
+	}
+}
+
+@PART[sspx-greenhouse-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 83.0
+		%surface = 131.1
 	}
 }
 
@@ -244,8 +581,8 @@
 {
 	@MODULE[Habitat]
 	{	
-		%volume = 66.3
-		%surface = 77.41
+		%volume = 51.7
+		%surface = 100.9
 	}
 }
 
@@ -272,8 +609,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 108.8
-		%surface = 159.48
+		%volume = 88.2
+		%surface = 110.0
 	}
 	
 	MODULE
@@ -286,12 +623,40 @@
 	@tags ^= :$: comfort:
 }
 
+@PART[sspx-airlock-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 20.0
+		%surface = 56.0
+	}
+}
+
 @PART[sspx-tube-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{	
-		%volume = 87.9
-		%surface = 111.8
+		%volume = 71.6
+		%surface = 116.57
 	}
 }
 
@@ -299,8 +664,8 @@
 {
 	@MODULE[Habitat]
 	{	
-		%volume = 44
-		%surface = 69.43
+		%volume = 34.7
+		%surface = 71.5
 	}
 }
 
@@ -308,14 +673,14 @@
 {
 	@MODULE[Habitat]
 	{	
-		%volume = 21.6
-		%surface = 47.91
+		%volume = 17.3
+		%surface = 48.9
 	}
 }
 
 
 //	=================================================================
-//	6.225m Modules - STOCKALIKE STATION PARTS EXPANSION REDUX
+//	6.75m Modules (Skylab) - STOCKALIKE STATION PARTS EXPANSION REDUX
 //
 //	sspx-attach-375-1
 //	sspx-core-375-1
@@ -335,8 +700,8 @@
 	
 	%MODULE[Habitat]
 	{	
-		%volume = 40.6
-		%surface = 66.17
+		%volume = 44.2
+		%surface = 91.1
 	}
 }
 
@@ -363,8 +728,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 94.3
-		%surface = 121.49
+		%volume = 84.9
+		%surface = 132.6
 	}
 }
 
@@ -391,8 +756,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 60.9
-		%surface = 99.98
+		%volume = 39.6
+		%surface = 110.0
 	}
 	
 	MODULE
@@ -428,8 +793,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 195
-		%surface = 186.03
+		%volume = 188
+		%surface = 220
 	}
 	
 	MODULE
@@ -464,8 +829,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 91.3
-		%surface = 119.54
+		%volume = 94
+		%surface = 145.8
 	}
 	
 	MODULE
@@ -500,8 +865,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 42.6
-		%surface = 68.25
+		%volume = 41.7
+		%surface = 75.6
 	}
 	
 	MODULE
@@ -511,6 +876,62 @@
 		bonus = exercise
 	}
 	@tags ^= :$: comfort:
+}
+
+@PART[sspx-greenhouse-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 83.2
+		%surface = 137.3
+	}
+}
+
+@PART[sspx-aquaculture-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 83.2
+		%surface = 137.3
+	}
 }
 
 @PART[sspx-lab-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -536,8 +957,8 @@
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 91.3
-		%surface = 119.54
+		%volume = 83.2
+		%surface = 137.3
 	}
 }
 
@@ -545,8 +966,8 @@
 {
 	@MODULE[Habitat]
 	{	
-		%volume = 396
-		%surface = 315.1
+		%volume = 197
+		%surface = 355.7
 	}
 }
 
@@ -554,8 +975,8 @@
 {
 	@MODULE[Habitat]
 	{	
-		%volume = 198
-		%surface = 187.99
+		%volume = 95.7
+		%surface = 211.5
 	}
 }
 
@@ -563,7 +984,665 @@
 {
 	@MODULE[Habitat]
 	{	
-		%volume = 91.3
-		%surface = 119.54
+		%volume = 48.6
+		%surface = 139.4
 	}
 }
+
+
+//	=================================================================
+//	9.0m Modules (Skylab II, Starship) - STOCKALIKE STATION PARTS EXPANSION REDUX
+//
+//
+//	=================================================================
+
+
+@PART[sspx-core-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+
+	@MODULE[Habitat]
+	{	
+		%volume = 210.0
+		%surface = 251.6
+	}
+}
+
+@PART[sspx-dome-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 190.8
+		%surface = 190.8
+	}
+	
+	MODULE
+	{
+		name = Comfort
+		bonus = panorama
+		desc = The cupola offer a relaxing panoramic view of the void of space.
+	}
+
+	@tags ^= :$: comfort:
+}
+
+@PART[sspx-dome-cupola-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 190.8
+		%surface = 190.8
+	}
+	
+	MODULE
+	{
+		name = Comfort
+		bonus = panorama
+		desc = The cupola offer a relaxing panoramic view of the void of space.
+	}
+
+	@tags ^= :$: comfort:
+}
+
+@PART[sspx-dome-greenhouse-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 190.8
+		%surface = 190.8
+	}
+	
+	MODULE
+	{
+		name = Comfort
+		bonus = panorama
+		desc = The cupola offer a relaxing panoramic view of the void of space.
+	}
+
+	// 	Also needs actual greenhouse added
+
+	@tags ^= :$: comfort:
+}
+
+@PART[sspx-dome-habitation-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 190.8
+		%surface = 190.8
+	}
+	
+	MODULE
+	{
+		name = Comfort
+		bonus = panorama
+		desc = The cupola offer a relaxing panoramic view of the void of space.
+	}
+
+	MODULE
+	{
+		name = Comfort
+		desc = Some low-g exercise equipment is included. The crew will love it.
+		bonus = exercise
+	}
+	@tags ^= :$: comfort:
+
+@PART[sspx-habitation-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 200
+		%surface = 300
+	}
+	
+	MODULE
+	{
+		name = Comfort
+		desc = Some low-g exercise equipment is included. The crew will love it.
+		bonus = exercise
+	}
+	@tags ^= :$: comfort:
+}
+
+@PART[sspx-habitation-5-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 119
+		%surface = 197
+	}
+	
+	MODULE
+	{
+		name = Comfort
+		desc = Some low-g exercise equipment is included. The crew will love it.
+		bonus = exercise
+	}
+	@tags ^= :$: comfort:
+}
+
+@PART[sspx-greenhouse-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 382
+		%surface = 353.4
+	}
+	
+		MODULE
+	{
+		name = Comfort
+		bonus = panorama
+		desc = Large windows offer a relaxing panoramic view of the void of space.
+	}
+	// 	Also needs actual greenhouse added
+	@tags ^= :$: comfort:
+}
+
+@PART[sspx-lab-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
+	@MODULE[Habitat]
+	{	
+		%volume = 150
+		%surface = 251
+	}
+}
+
+@PART[sspx-logistics-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 100
+		%surface = 171
+	}
+}
+
+@PART[sspx-logistics-5-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 52
+		%surface = 108
+	}
+}
+
+//	=================================================================
+//	Extendables
+
+@PART[sspx-inflatable-*,sspx-expandable-*]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	// Kerbalism forces the habitat to be inflated if kerbals are inside
+	@CrewCapacity = #$MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
+
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+
+@PART[sspx-inflatable-hab-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		inflate = Expand
+		state = disabled
+		animBackwards = True
+		volume = 69.7
+		surface = 125
+	}
+
+	!MODULE[ModuleDeployableHabitat] {} 
+}
+
+@PART[sspx-inflatable-hab-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		inflate = Expand
+		state = disabled
+		animBackwards = True
+		volume = 25.7
+		surface = 50
+	}
+
+	!MODULE[ModuleDeployableHabitat] {} 
+}
+
+@PART[sspx-inflatable-hab-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		inflate = Expand
+		state = disabled
+		animBackwards = True
+		volume = 25.7
+		surface = 50
+	}
+
+	!MODULE[ModuleDeployableHabitat] {} 
+}
+
+@PART[sspx-inflatable-centrifuge-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		state = disabled
+		volume = 110
+		surface = 173
+	}
+
+	MODULE
+	{
+		name = GravityRing
+		ec_rate = 2.5
+		animBackwards = True
+		deploy = Expand
+		rotate = SpinCenter
+		deployed = False
+		rotateIsTransform = True
+		SpinRate = 42
+
+		counterWeightRotate = SpinCenterCounter
+		counterWeightSpinRate = -84.0
+		counterWeightSpinAccelerationRate = 2.0
+	}
+
+	!MODULE[ModuleDeployableCentrifuge] {} 
+}
+
+@PART[sspx-inflatable-centrifuge-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		state = disabled
+		volume = 54
+		surface = 170
+	}
+
+	MODULE
+	{
+		name = GravityRing
+		ec_rate = 2.5
+		animBackwards = True
+		deploy = Expand
+		rotate = CompactSpinCentre
+		deployed = False
+		rotateIsTransform = True
+
+		counterWeightRotate = CounterWeight
+		counterWeightSpinRate = -70
+		counterWeightSpinAccelerationRate = 2
+	}
+
+	!MODULE[ModuleDeployableCentrifuge] {}
+}
+
+@PART[sspx-inflatable-hab-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		inflate = Expand
+		state = disabled
+		animBackwards = True
+		volume = 635
+		surface = 550
+	}
+
+	!MODULE[ModuleDeployableHabitat] {} 
+}
+
+
+@PART[sspx-inflatable-hab-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		inflate = Expand
+		state = disabled
+		animBackwards = True
+		volume = 289
+		surface = 320
+	}
+
+	!MODULE[ModuleDeployableHabitat] {} 
+}
+
+@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		state = disabled
+		volume = 248
+		surface = 516
+	}
+
+	MODULE
+	{
+		name = GravityRing
+		ec_rate = 2.5
+		animBackwards = True
+		deploy = Expand
+		rotate = B_Rotation
+		rotateIsTransform = True
+		SpinRate = 45
+		SpinAccelerationRate = 1
+
+		counterWeightRotate = 25mTorusCounterweight
+		counterWeightSpinRate = -90
+		counterWeightSpinAccelerationRate = 2
+	}
+
+	!MODULE[ModuleDeployableCentrifuge] {}
+}
+
+@PART[sspx-expandable-centrifuge-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		state = disabled
+		inflatableUsingRigidWalls = True
+		volume = 922
+		surface = 1411
+	}
+
+	MODULE
+	{
+		name = GravityRing
+		ec_rate = 2.5
+		animBackwards = True
+		deploy = CentrifugeCollapse
+		rotate = B_Center
+		deployed = False
+		rotateIsTransform = True
+		SpinRate = 35
+
+		counterWeightRotate = Counterweight
+		counterWeightSpinRate = -70
+		counterWeightSpinAccelerationRate = 2
+	}
+
+	!MODULE[ModuleDeployableCentrifuge] {}
+}
+
+@PART[sspx-expandable-centrifuge-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		state = disabled
+		inflatableUsingRigidWalls = True
+		volume = 350
+		surface = 650
+	}
+
+	MODULE
+	{
+		name = GravityRing
+		ec_rate = 2.5
+		animBackwards = True
+		deploy = Retract
+		rotate = SpinCenter
+		deployed = False
+		rotateIsTransform = True
+		SpinRate = 25
+
+		counterWeightRotate = Counterweights
+		counterWeightSpinRate = -70
+		counterWeightSpinAccelerationRate = 2
+	}
+
+	!MODULE[ModuleDeployableCentrifuge] {}
+}
+
+@PART[sspx-expandable-centrifuge-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Habitat
+		state = disabled
+		inflatableUsingRigidWalls = True
+		volume = 1300
+		surface = 5900
+	}
+
+	MODULE
+	{
+		name = GravityRing
+		ec_rate = 2.5
+		animBackwards = True
+		deploy = CentrifugeCollapse
+		rotate = B_Center
+		deployed = False
+		rotateIsTransform = True
+		SpinRate = 35
+
+		counterWeightRotate = Counterweight
+		counterWeightSpinRate = -70
+		counterWeightSpinAccelerationRate = 2
+	}
+
+	!MODULE[ModuleDeployableCentrifuge] {}
+}
+
+//	=================================================================
+//	Adapters
+
+@PART[sspx-adapter-1875-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 4.73
+		%surface = 23.1
+	}
+}
+
+@PART[sspx-adapter-125-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 9.05
+		%surface = 38.1
+	}
+}
+
+@PART[sspx-adapter-25-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 12.0
+		%surface = 42.4
+	}
+}
+
+@PART[sspx-adapter-25-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 26.1
+		%surface = 84.8
+	}
+}
+
+@PART[sspx-adapter-375-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 48.6
+		%surface = 139.4
+	}
+}
+
+

--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -32,7 +32,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 7.7
 		%surface = 24.1
@@ -41,7 +41,7 @@
 
 @PART[sspx-cupola-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 3.36
 		%surface = 19.9
@@ -59,7 +59,7 @@
 
 @PART[sspx-cupola-greenhouse-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 2.24
 		%surface = 19.9
@@ -98,7 +98,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 14.12
 		%surface = 36.1
@@ -126,7 +126,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 2.28
 		%surface = 36
@@ -155,7 +155,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 2.0
 		%surface = 14.5
@@ -164,7 +164,7 @@
 
 @PART[sspx-tube-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 17.1
 		%surface = 58.8
@@ -173,7 +173,7 @@
 
 @PART[sspx-tube-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 8.55
 		%surface = 33.4
@@ -182,7 +182,7 @@
 
 @PART[sspx-tube-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 5.7
 		%surface = 20.7
@@ -191,7 +191,7 @@
 
 @PART[sspx-hub-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 9.3
 		%surface = 34.6
@@ -237,7 +237,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 16.0
 		%surface = 60.8
@@ -284,7 +284,7 @@
 	}
 	@tags ^= :$: comfort:
 
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 48.4
 		%surface = 91.3
@@ -312,7 +312,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 24.2
 		%surface = 56.4
@@ -340,7 +340,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 21.0
 		%surface = 71.5
@@ -368,7 +368,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 21.0
 		%surface = 71.5
@@ -396,7 +396,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 17.1
 		%surface = 25.0
@@ -406,7 +406,7 @@
 
 @PART[sspx-hub-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 63.8
 		%surface = 63.6
@@ -416,7 +416,7 @@
 
 @PART[sspx-tube-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 38.5
 		%surface = 67.8
@@ -425,7 +425,7 @@
 
 @PART[sspx-tube-1875-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 29.7
 		%surface = 40.5
@@ -434,7 +434,7 @@
 
 @PART[sspx-tube-1875-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 7.4
 		%surface = 26.9
@@ -443,7 +443,7 @@
 
 @PART[sspx-tube-1875-angled-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 17.0
 		%surface = 55.6
@@ -495,7 +495,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 49.3
 		%surface = 83.74
@@ -542,7 +542,7 @@
 	}
 	@tags ^= :$: comfort:
 
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 83.0
 		%surface = 131.1
@@ -570,7 +570,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 83.0
 		%surface = 131.1
@@ -579,7 +579,7 @@
 
 @PART[sspx-hub-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 51.7
 		%surface = 100.9
@@ -607,10 +607,10 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 88.2
-		%surface = 110.0
+		%surface = 125.0
 	}
 	
 	MODULE
@@ -621,6 +621,35 @@
 	}
 
 	@tags ^= :$: comfort:
+}
+
+@PART[crewCabin]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	
+	%MODULE[Habitat]
+	{	
+		%volume = 65.3
+		%surface = 109.1
+	}
+}
+
+@PART[cupola]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	%MODULE[Habitat]
+	{	
+		%volume = 11.9
+		%surface = 46.0
+	}
+
+}
+
+@PART[Large_Crewed_Lab]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul,KerbalismConfig]
+{
+	%MODULE[Habitat]
+	{	
+		%volume = 78.7
+		%surface = 125.1
+	}
 }
 
 @PART[sspx-airlock-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -644,7 +673,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 20.0
 		%surface = 56.0
@@ -653,7 +682,7 @@
 
 @PART[sspx-tube-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 71.6
 		%surface = 116.57
@@ -662,7 +691,7 @@
 
 @PART[sspx-tube-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 34.7
 		%surface = 71.5
@@ -671,7 +700,7 @@
 
 @PART[sspx-tube-25-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 17.3
 		%surface = 48.9
@@ -726,7 +755,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 84.9
 		%surface = 132.6
@@ -754,7 +783,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 39.6
 		%surface = 110.0
@@ -791,7 +820,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 188
 		%surface = 220
@@ -827,7 +856,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 94
 		%surface = 145.8
@@ -863,7 +892,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 41.7
 		%surface = 75.6
@@ -899,7 +928,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 83.2
 		%surface = 137.3
@@ -927,7 +956,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 83.2
 		%surface = 137.3
@@ -955,7 +984,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 83.2
 		%surface = 137.3
@@ -964,7 +993,7 @@
 
 @PART[sspx-tube-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 197
 		%surface = 355.7
@@ -973,7 +1002,7 @@
 
 @PART[sspx-tube-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 95.7
 		%surface = 211.5
@@ -982,7 +1011,7 @@
 
 @PART[sspx-tube-375-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 48.6
 		%surface = 139.4
@@ -1019,7 +1048,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 210.0
 		%surface = 251.6
@@ -1029,7 +1058,7 @@
 @PART[sspx-dome-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 190.8
 		%surface = 190.8
@@ -1066,7 +1095,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 190.8
 		%surface = 190.8
@@ -1103,7 +1132,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 190.8
 		%surface = 190.8
@@ -1142,7 +1171,7 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 190.8
 		%surface = 190.8
@@ -1162,6 +1191,7 @@
 		bonus = exercise
 	}
 	@tags ^= :$: comfort:
+}
 
 @PART[sspx-habitation-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
@@ -1184,10 +1214,10 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
-		%volume = 200
-		%surface = 300
+		%volume = 200.0
+		%surface = 300.0
 	}
 	
 	MODULE
@@ -1220,10 +1250,10 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
-		%volume = 119
-		%surface = 197
+		%volume = 119.0
+		%surface = 197.0
 	}
 	
 	MODULE
@@ -1251,14 +1281,14 @@
 		running = true
 	}
 	
-	@MODULE[ProcessController],*
+	MODULE[ProcessController],*
 	{
 		@capacity *= #$/CrewCapacity$
 	}
 	
 	@MODULE[Habitat]
 	{	
-		%volume = 382
+		%volume = 382.0
 		%surface = 353.4
 	}
 	
@@ -1293,35 +1323,35 @@
 		@capacity *= #$/CrewCapacity$
 	}
 	
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
-		%volume = 150
-		%surface = 251
+		%volume = 150.0
+		%surface = 251.0
 	}
 }
 
 @PART[sspx-logistics-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
-		%volume = 100
-		%surface = 171
+		%volume = 100.0
+		%surface = 171.0
 	}
 }
 
 @PART[sspx-logistics-5-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
-		%volume = 52
-		%surface = 108
+		%volume = 52.0
+		%surface = 108.0
 	}
 }
 
 //	=================================================================
 //	Extendables
 
-@PART[sspx-inflatable-*,sspx-expandable-*]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-inflatable-cen*,sspx-expandable-cen*]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
 	// Kerbalism forces the habitat to be inflated if kerbals are inside
 	@CrewCapacity = #$MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
@@ -1344,8 +1374,34 @@
 	{
 		@capacity *= #$/CrewCapacity$
 	}
+}
 
-@PART[sspx-inflatable-hab-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-inflatable-hab*]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+{
+	// Kerbalism forces the habitat to be inflated if kerbals are inside
+	@CrewCapacity = #$MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
+
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+}
+
+@PART[sspx-inflatable-hab-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
@@ -1354,13 +1410,28 @@
 		state = disabled
 		animBackwards = True
 		volume = 69.7
-		surface = 125
+		surface = 125.0
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
 }
 
-@PART[sspx-inflatable-hab-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-inflatable-hab-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+{
+	MODULE
+	{
+		name = Habitat
+		inflate = Expand
+		state = disabled
+		animBackwards = True
+		volume = 25.7
+		surface = 50.0
+	}
+
+	!MODULE[ModuleDeployableHabitat] {} 
+}
+
+@PART[sspx-inflatable-hab-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
@@ -1375,29 +1446,14 @@
 	!MODULE[ModuleDeployableHabitat] {} 
 }
 
-@PART[sspx-inflatable-hab-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
-{
-	MODULE
-	{
-		name = Habitat
-		inflate = Expand
-		state = disabled
-		animBackwards = True
-		volume = 25.7
-		surface = 50
-	}
-
-	!MODULE[ModuleDeployableHabitat] {} 
-}
-
-@PART[sspx-inflatable-centrifuge-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-inflatable-centrifuge-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
 		name = Habitat
 		state = disabled
-		volume = 110
-		surface = 173
+		volume = 110.0
+		surface = 173.0
 	}
 
 	MODULE
@@ -1419,14 +1475,14 @@
 	!MODULE[ModuleDeployableCentrifuge] {} 
 }
 
-@PART[sspx-inflatable-centrifuge-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-inflatable-centrifuge-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
 		name = Habitat
 		state = disabled
-		volume = 54
-		surface = 170
+		volume = 54.0
+		surface = 170.0
 	}
 
 	MODULE
@@ -1447,7 +1503,7 @@
 	!MODULE[ModuleDeployableCentrifuge] {}
 }
 
-@PART[sspx-inflatable-hab-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-inflatable-hab-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
@@ -1455,15 +1511,15 @@
 		inflate = Expand
 		state = disabled
 		animBackwards = True
-		volume = 635
-		surface = 550
+		volume = 635.0
+		surface = 550.0
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
 }
 
 
-@PART[sspx-inflatable-hab-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-inflatable-hab-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
@@ -1471,21 +1527,21 @@
 		inflate = Expand
 		state = disabled
 		animBackwards = True
-		volume = 289
-		surface = 320
+		volume = 289.0
+		surface = 320.0
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
 }
 
-@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
 		name = Habitat
 		state = disabled
-		volume = 248
-		surface = 516
+		volume = 248.0
+		surface = 516.0
 	}
 
 	MODULE
@@ -1507,7 +1563,7 @@
 	!MODULE[ModuleDeployableCentrifuge] {}
 }
 
-@PART[sspx-expandable-centrifuge-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-expandable-centrifuge-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
@@ -1537,7 +1593,7 @@
 	!MODULE[ModuleDeployableCentrifuge] {}
 }
 
-@PART[sspx-expandable-centrifuge-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-expandable-centrifuge-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
@@ -1567,7 +1623,7 @@
 	!MODULE[ModuleDeployableCentrifuge] {}
 }
 
-@PART[sspx-expandable-centrifuge-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[KerbalismDefault]
+@PART[sspx-expandable-centrifuge-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
 {
 	MODULE
 	{
@@ -1602,7 +1658,7 @@
 
 @PART[sspx-adapter-1875-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 4.73
 		%surface = 23.1
@@ -1611,7 +1667,7 @@
 
 @PART[sspx-adapter-125-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 9.05
 		%surface = 38.1
@@ -1620,7 +1676,7 @@
 
 @PART[sspx-adapter-25-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 12.0
 		%surface = 42.4
@@ -1629,7 +1685,7 @@
 
 @PART[sspx-adapter-25-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 26.1
 		%surface = 84.8
@@ -1638,7 +1694,7 @@
 
 @PART[sspx-adapter-375-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Habitat]
+	%MODULE[Habitat]
 	{	
 		%volume = 48.6
 		%surface = 139.4

--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -849,9 +849,9 @@
 	{
 		name = ProcessController
 		resource = _algae
-		title = Algae Bioreactor
+		title = Greenhouse
 		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
-		capacity = 1.67
+		capacity = 33.4 //1.67*40*0.5 40kL of space for plants. Algae production values are for 100L, for plants lets assume 10 times worse. Also divided by crew capacity of 2.
 		toggle = true
 		running = true
 	}
@@ -908,7 +908,7 @@
 	
 	%MODULE[Habitat]
 	{	
-		%volume = 83.0
+		%volume = 47.0
 		%surface = 131.1
 	}
 	
@@ -1510,7 +1510,7 @@
 		resource = _algae
 		title = Greenhouse
 		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
-		capacity = 1.67
+		capacity = 22.04 // 1.67*40*0.33 40kL of space for plants. Algae production values are for 100L, for plants lets assume 10 times worse. Also divided by crew capacity of 4.
 		toggle = true
 		running = true
 	}
@@ -1522,7 +1522,7 @@
 	
 	%MODULE[Habitat]
 	{	
-		%volume = 83.2
+		%volume = 40.1
 		%surface = 137.3
 	}
 	
@@ -1604,7 +1604,7 @@
 		resource = _algae
 		title = Algae Bioreactor
 		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
-		capacity = 1.67
+		capacity = 110.2 // 1.67*200*0.33 Algae config is for 100L unit, the part has enough space to fit 20kL unit. Also divided by crew capacity
 		toggle = true
 		running = true
 	}
@@ -1616,7 +1616,7 @@
 	
 	%MODULE[Habitat]
 	{	
-		%volume = 83.2
+		%volume = 43.2
 		%surface = 137.3
 	}
 	
@@ -1957,7 +1957,7 @@
 		resource = _algae
 		title = Greenhouse
 		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
-		capacity = 1.67
+		capacity = 125.25 // 1.67*150.*0.5 150kL of space for plants. Algae production values are for 100L, for plants lets assume 10 times worse. Also divided by crew capacity of 2.
 		toggle = true
 		running = true
 	}
@@ -2349,7 +2349,7 @@
 		resource = _algae
 		title = Algae Bioreactor
 		desc = Produces <b>Food</b>, <b>Water</b> and <b>Oxygen</b> from <b>CarbonDioxide</b> and <b>WasteWater</b>.
-		capacity = 1.67
+		capacity = 125.25 // 1.67*300.*0.25 300kL of space for plants. Algae production values are for 100L, for plants lets assume 10 times worse. Also divided by crew capacity of 4.
 		toggle = true
 		running = true
 	}
@@ -2880,13 +2880,13 @@
 		ec_rate = 2.5
 		animBackwards = True
 		deploy = CentrifugeCollapse
-		rotate = B_Center
+		rotate = B_SpinCore
 		deployed = False
 		rotateIsTransform = True
-		SpinRate = 35
+		SpinRate = -35
 
-		counterWeightRotate = Counterweight
-		counterWeightSpinRate = -70
+		counterWeightRotate = B_Counterweight
+		counterWeightSpinRate = 70
 		counterWeightSpinAccelerationRate = 2
 	}
 

--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -72,7 +72,12 @@
 		desc = The cupola offer a relaxing panoramic view of the void of space.
 	}
 
-	// 	Also needs actual greenhouse added
+		MODULE
+	{
+		name = Comfort
+		bonus = plants
+		desc =  There's something inherently calming about an artificial slice of nature, kept alive only by the miracles of duct-tape and kerbal engineering. Let's hope the crew doesn't think too much about it.
+	}
 
 	@tags ^= :$: comfort:
 }
@@ -575,6 +580,16 @@
 		%volume = 83.0
 		%surface = 131.1
 	}
+	
+	MODULE
+	{
+		name = Comfort
+		bonus = plants
+		desc =  There's something inherently calming about an artificial slice of nature, kept alive only by the miracles of duct-tape and kerbal engineering. Let's hope the crew doesn't think too much about it.
+	}
+
+	@tags ^= :$: comfort:
+
 }
 
 @PART[sspx-hub-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -933,6 +948,16 @@
 		%volume = 83.2
 		%surface = 137.3
 	}
+	
+		MODULE
+	{
+		name = Comfort
+		bonus = plants
+		desc =  There's something inherently calming about an artificial slice of nature, kept alive only by the miracles of duct-tape and kerbal engineering. Let's hope the crew doesn't think too much about it.
+	}
+
+	@tags ^= :$: comfort:
+	
 }
 
 @PART[sspx-aquaculture-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul]:AFTER[RealismOverhaul]
@@ -1145,7 +1170,12 @@
 		desc = The cupola offer a relaxing panoramic view of the void of space.
 	}
 
-	// 	Also needs actual greenhouse added
+		MODULE
+	{
+		name = Comfort
+		bonus = plants
+		desc =  There's something inherently calming about an artificial slice of nature, kept alive only by the miracles of duct-tape and kerbal engineering. Let's hope the crew doesn't think too much about it.
+	}
 
 	@tags ^= :$: comfort:
 }
@@ -1298,7 +1328,13 @@
 		bonus = panorama
 		desc = Large windows offer a relaxing panoramic view of the void of space.
 	}
-	// 	Also needs actual greenhouse added
+		MODULE
+	{
+		name = Comfort
+		bonus = plants
+		desc =  There's something inherently calming about an artificial slice of nature, kept alive only by the miracles of duct-tape and kerbal engineering. Let's hope the crew doesn't think too much about it.
+	}
+
 	@tags ^= :$: comfort:
 }
 
@@ -1351,30 +1387,6 @@
 //	=================================================================
 //	Extendables
 
-@PART[sspx-inflatable-cen*,sspx-expandable-cen*]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
-{
-	// Kerbalism forces the habitat to be inflated if kerbals are inside
-	@CrewCapacity = #$MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
-
-	%capsuleScrubbers = true
-	%scrubberCapacity = 1.67
-	
-	MODULE
-	{
-		name = ProcessController
-		resource = _PressureControl
-		title = N2 Pressure Controller
-		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-		capacity = 1.67
-		toggle = true
-		running = true
-	}
-	
-	@MODULE[ProcessController],*
-	{
-		@capacity *= #$/CrewCapacity$
-	}
-}
 
 @PART[sspx-inflatable-hab*]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
@@ -1399,61 +1411,103 @@
 	{
 		@capacity *= #$/CrewCapacity$
 	}
-}
-
-@PART[sspx-inflatable-hab-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
-{
+	
 	MODULE
 	{
 		name = Habitat
 		inflate = Expand
 		state = disabled
 		animBackwards = True
-		volume = 69.7
-		surface = 125.0
 	}
-
-	!MODULE[ModuleDeployableHabitat] {} 
+	
 }
 
-@PART[sspx-inflatable-hab-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-inflatable-cen*,sspx-expandable-cen*]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
+	// Kerbalism forces the habitat to be inflated if kerbals are inside
+	@CrewCapacity = #$MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
+
+	%capsuleScrubbers = true
+	%scrubberCapacity = 1.67
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+		capacity = 1.67
+		toggle = true
+		running = true
+	}
+	
+	@MODULE[ProcessController],*
+	{
+		@capacity *= #$/CrewCapacity$
+	}
+	
 	MODULE
 	{
 		name = Habitat
 		inflate = Expand
 		state = disabled
 		animBackwards = True
-		volume = 25.7
-		surface = 50.0
+	}
+	
+	MODULE
+	{
+		name = Comfort
+		bonus = exercise
+		desc = A treadmill designed to permit exercise in zero-g is included. The crew will love it.
+	}
+	MODULE
+	{
+		name = Comfort
+		bonus = firmground
+		desc = Having something to walk on
+	}
+	
+}
+
+@PART[sspx-inflatable-hab-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 69.7
+		%surface = 125.0
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
 }
 
-@PART[sspx-inflatable-hab-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-inflatable-hab-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = Habitat
-		inflate = Expand
-		state = disabled
-		animBackwards = True
-		volume = 25.7
-		surface = 50
+	@MODULE[Habitat]
+	{	
+		%volume = 25.7
+		%surface = 50.0
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
 }
 
-@PART[sspx-inflatable-centrifuge-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-inflatable-hab-125-3]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = Habitat
-		state = disabled
-		volume = 110.0
-		surface = 173.0
+	@MODULE[Habitat]
+	{	
+		%volume = 25.7
+		%surface = 50
+	}
+
+	!MODULE[ModuleDeployableHabitat] {} 
+}
+
+@PART[sspx-inflatable-centrifuge-125-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 110.0
+		%surface = 173.0
 	}
 
 	MODULE
@@ -1475,14 +1529,12 @@
 	!MODULE[ModuleDeployableCentrifuge] {} 
 }
 
-@PART[sspx-inflatable-centrifuge-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-inflatable-centrifuge-125-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = Habitat
-		state = disabled
-		volume = 54.0
-		surface = 170.0
+	@MODULE[Habitat]
+	{	
+		%volume = 54.0
+		%surface = 170.0
 	}
 
 	MODULE
@@ -1503,45 +1555,35 @@
 	!MODULE[ModuleDeployableCentrifuge] {}
 }
 
-@PART[sspx-inflatable-hab-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-inflatable-hab-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = Habitat
-		inflate = Expand
-		state = disabled
-		animBackwards = True
-		volume = 635.0
-		surface = 550.0
+	@MODULE[Habitat]
+	{	
+		%volume = 635.0
+		%surface = 550.0
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
 }
 
 
-@PART[sspx-inflatable-hab-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-inflatable-hab-25-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = Habitat
-		inflate = Expand
-		state = disabled
-		animBackwards = True
-		volume = 289.0
-		surface = 320.0
+	@MODULE[Habitat]
+	{	
+		%volume = 289.0
+		%surface = 320.0
 	}
 
 	!MODULE[ModuleDeployableHabitat] {} 
 }
 
-@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = Habitat
-		state = disabled
-		volume = 248.0
-		surface = 516.0
+	@MODULE[Habitat]
+	{	
+		%volume = 248.0
+		%surface = 516.0
 	}
 
 	MODULE
@@ -1563,15 +1605,12 @@
 	!MODULE[ModuleDeployableCentrifuge] {}
 }
 
-@PART[sspx-expandable-centrifuge-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-expandable-centrifuge-375-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = Habitat
-		state = disabled
-		inflatableUsingRigidWalls = True
-		volume = 922
-		surface = 1411
+	@MODULE[Habitat]
+	{	
+		%volume = 922
+		%surface = 1411
 	}
 
 	MODULE
@@ -1593,15 +1632,12 @@
 	!MODULE[ModuleDeployableCentrifuge] {}
 }
 
-@PART[sspx-expandable-centrifuge-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-expandable-centrifuge-375-2]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = Habitat
-		state = disabled
-		inflatableUsingRigidWalls = True
-		volume = 350
-		surface = 650
+	@MODULE[Habitat]
+	{	
+		%volume = 350
+		%surface = 650
 	}
 
 	MODULE
@@ -1623,15 +1659,12 @@
 	!MODULE[ModuleDeployableCentrifuge] {}
 }
 
-@PART[sspx-expandable-centrifuge-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul,zzzKerbalism]
+@PART[sspx-expandable-centrifuge-5-1]:NEEDS[StationPartsExpansionRedux,ProfileRealismOverhaul,FeatureHabitat]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = Habitat
-		state = disabled
-		inflatableUsingRigidWalls = True
-		volume = 1300
-		surface = 5900
+	@MODULE[Habitat]
+	{	
+		%volume = 1300
+		%surface = 5900
 	}
 
 	MODULE


### PR DESCRIPTION
- Masses, volumes, surface areas, resources are updated to new 1.8 scaling
- Latest SSPX parts, 1.875m (3.38m in RO) and 5m (9m in RO) are now supported
- Tubes, adapters etc. have habitable volumes
- Habitat modules have pre-filled resources for long duration flights
- More advanced habitats provide water purification
- Greenhouses provide resource conversion and comfort
- Centrifuges work and provide comfort
- Extendables carry enough Nitrogen to be used for their extension
- Also, see RO and RP-1 changes