### PR TITLE
Add support for the ROC Zenit camera system

### DIFF
--- a/GameData/KerbalismConfig/System/Science/HardDriveConfigs.cfg
+++ b/GameData/KerbalismConfig/System/Science/HardDriveConfigs.cfg
@@ -554,7 +554,7 @@ KERBALISM_HDD_SIZES
 }
 
 // Photography 2
-@PART[RO-ImprovedFilmCamera]:NEEDS[FeatureScience,RP-0]:AFTER[RP-0-KerbalismHardDrives]
+@PART[RO-ImprovedFilmCamera|ROC-ZenitCapsule]:NEEDS[FeatureScience,RP-0]:AFTER[RP-0-KerbalismHardDrives]
 {
 	MODULE
 	{

--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/Photography.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/Photography.cfg
@@ -196,7 +196,7 @@
 // ============================================================================
 // Add experiment to parts
 // ============================================================================
-@PART[RO-ImprovedFilmCamera]:NEEDS[FeatureScience,RP-0]:BEFORE[RP-0-Kerbalism]
+@PART[RO-ImprovedFilmCamera|ROC-ZenitCapsule]:NEEDS[FeatureScience,RP-0]:BEFORE[RP-0-Kerbalism]
 {
 	MODULE
     {


### PR DESCRIPTION
Add support for the ROC Zenit camera system. This just models the early Zenit models as the improved film camera.

ROC PR: https://github.com/KSP-RO/ROCapsules/pull/114