### PR TITLE
Hab tech2

### DIFF
--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -157,7 +157,7 @@
 			name = Sabatier Process
 			desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>. Can handle CO2 from 3 crew members.
 			tech = advancedLifeSupport
-			mass = 0.329 //  ISS CRS is 329 kgs for 4 crew
+			mass = 0.247 //  ISS CRS is 329 kgs for 4 crew
 			cost = 50 //FIXME
 
 			MODULE
@@ -176,6 +176,16 @@
 	@MODULE[Configure]
 	{
 		@slots = 2 // just an example currently
+	}
+}
+
+@PART[ht2_moduleCupola]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = Comfort
+		bonus = panorama
+		desc = The cupola offer a relaxing panoramic view of the void of space.
 	}
 }
 

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -7,18 +7,6 @@
 		title = Modular Life Support
 
 		slots = 2 // just an example currently
-
-		SETUP
-		{
-			name = None
-			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
-		}
-
-		SETUP
-		{
-			name = None 2
-			desc = Empty slot 2
-		}
 	}
 }
 
@@ -40,18 +28,6 @@
 		title = Modular Life Support
 
 		slots = 2 // just an example currently
-
-		SETUP
-		{
-			name = None
-			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
-		}
-
-		SETUP
-		{
-			name = None 2
-			desc = Empty slot 2
-		}
 	}
 }
 
@@ -70,12 +46,6 @@
 		title = Modular Life Support
 
 		slots = 1 // just an example currently
-
-		SETUP
-		{
-			name = None
-			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
-		}
 	}
 }
 
@@ -87,24 +57,6 @@
 		title = Modular Life Support
 
 		slots = 3 // just an example currently
-
-		SETUP
-		{
-			name = None
-			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
-		}
-
-		SETUP
-		{
-			name = None 2
-			desc = Empty slot 2
-		}
-
-		SETUP
-		{
-			name = None 3
-			desc = Empty slot 3
-		}
 	}
 }
 
@@ -116,12 +68,6 @@
 		title = Modular Life Support
 
 		slots = 1 // just an example currently
-
-		SETUP
-		{
-			name = None
-			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
-		}
 	}
 }
 
@@ -133,18 +79,6 @@
 		title = Modular Life Support
 
 		slots = 2 // just an example currently
-
-		SETUP
-		{
-			name = None
-			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
-		}
-
-		SETUP
-		{
-			name = None 2
-			desc = Empty slot 2
-		}
 	}
 }
 
@@ -156,24 +90,6 @@
 		title = Modular Life Support
 
 		slots = 3 // just an example currently
-
-		SETUP
-		{
-			name = None
-			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
-		}
-
-		SETUP
-		{
-			name = None 2
-			desc = Empty slot 2
-		}
-
-		SETUP
-		{
-			name = None 3
-			desc = Empty slot 3
-		}
 	}
 }
 
@@ -341,6 +257,33 @@
 		// 1 capacity >= 3 crew output CO2
 		capacity = 1
 		running = true
+	}
+
+	@MODULE[Configure]:HAS[@slots[>0]]
+	{
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+	}
+
+	@MODULE[Configure]:HAS[@slots[>1]]
+	{
+		SETUP
+		{
+			name = None 2
+			desc = Empty slot 2
+		}
+	}
+
+	@MODULE[Configure]:HAS[@slots[>2]]
+	{
+		SETUP
+		{
+			name = None 3
+			desc = Empty slot 3
+		}
 	}
 
 	processConfigureExclude = true

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -6,7 +6,7 @@
 		name = Configure
 		title = Modular Life Support
 
-		slots = 2 // just an example currently
+		slots = 2
 	}
 }
 
@@ -27,7 +27,7 @@
 		name = Configure
 		title = Modular Life Support
 
-		slots = 2 // just an example currently
+		slots = 2
 	}
 }
 
@@ -45,7 +45,7 @@
 		name = Configure
 		title = Modular Life Support
 
-		slots = 1 // just an example currently
+		slots = 1
 	}
 }
 
@@ -56,7 +56,7 @@
 		name = Configure
 		title = Modular Life Support
 
-		slots = 3 // just an example currently
+		slots = 3
 	}
 }
 
@@ -67,7 +67,7 @@
 		name = Configure
 		title = Modular Life Support
 
-		slots = 1 // just an example currently
+		slots = 1
 	}
 }
 
@@ -78,7 +78,7 @@
 		name = Configure
 		title = Modular Life Support
 
-		slots = 2 // just an example currently
+		slots = 2
 	}
 }
 
@@ -89,7 +89,7 @@
 		name = Configure
 		title = Modular Life Support
 
-		slots = 3 // just an example currently
+		slots = 3
 	}
 }
 

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -1,72 +1,12 @@
-// Defines the Life Support equipment that exists on ISS for all parts
-@PART[ht2_moduleColumbus|ht2_moduleDestiny|ht2_moduleHarmony|ht2_moduleKibo|ht2_moduleQuest|ht2_moduleUnity|ht2_moduleLabNode]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+// Patches to individual parts based on the general configs at the bottom of the file
+@PART[ht2_moduleColumbus]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
 	MODULE
 	{
-		name = ProcessController
-		resource = _VacScrubber
-		title = Vacuum Scrubber
-		// 1 capacity = 1 crew output
-		capacity = 6
-		running = true
-	}
-
-	MODULE
-	{
-		name = ProcessController
-		resource = _PressureControl
-		title = N2 Pressure Controller
-		// 1 capacity = 70 m^2
-		capacity = 15
-		running = true
-	}
-
-	MODULE
-	{
-		name = ProcessController
-		resource = _PressureControlOxygen
-		title = O2 Pressure Controller
-		// 1 capacity = 70 m^2
-		capacity = 15
-		running = true
-	}
-
-	MODULE
-	{
-		name = ProcessController
-		resource = _WaterRecycler
-		title = Water Recycler
-		// 1 capacity = 1 crew output
-		capacity = 6
-		running = true
-	}
-
-	MODULE
-	{
-		name = ProcessController
-		resource = _WaterElectrolysis
-		title = Water electrolysis
-		// 1 capacity >= 1 crew output
-		capacity = 4
-		running = true
-	}
-
-	MODULE
-	{
-		name = ProcessController
-		resource = _Sabatier
-		title = Sabatier process
-		// 1 capacity >= 3 crew output CO2
-		capacity = 1
-		running = true
-	}
-
-	processConfigureExclude = true
-	MODULE
-	{
 		name = Configure
-		title = Module Life Support
-		slots = 1
+		title = Modular Life Support
+
+		slots = 2 // just an example currently
 
 		SETUP
 		{
@@ -76,106 +16,9 @@
 
 		SETUP
 		{
-			name = Vacuum Scrubber
-			desc = A dual-bed vacuum-exposing regenerative scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere. Can work indefinitely. Can support a crew of 6.
-			tech = basicLifeSupport
-			mass = 0.2 //FIXME
-			cost = 25 //FIXME
-
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _VacScrubber
-			}
+			name = None 2
+			desc = Empty slot 2
 		}
-
-		SETUP
-		{
-			name = N2 Pressure Control
-			desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
-			mass = 0.05 //FIXME
-			cost = 25 //FIXME
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _PressureControl
-			}
-		}
-
-		SETUP
-		{
-			name = O2 Pressure Control
-			desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
-			mass = 0.01 //FIXME
-			cost = 25 //FIXME
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _PressureControlOxygen
-			}
-		}
-
-		SETUP
-		{
-			name = Water Recycler
-			desc = Filter impurities out of <b>WasteWater</b>. Can support a crew of 6.
-			tech = advancedLifeSupport
-			mass = 1.113 //  Using ISS urine processing system since that's our only wastewater generator, 742kg for 4 crew
-			cost = 50 //FIXME
-
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _WaterRecycler
-			}
-		}
-
-		SETUP
-		{
-			name = Water Electrolysis
-			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components. Can support a crew of 4.
-			tech = longTermLifeSupport
-			mass = 0.676 // ISS OGS is 676 kgs for 4 crew
-			cost = 50 //FIXME
-
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _WaterElectrolysis
-			}
-		}
-
-		SETUP
-		{
-			name = Sabatier Process
-			desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>. Can handle CO2 from 3 crew members.
-			tech = advancedLifeSupport
-			mass = 0.247 //  ISS CRS is 329 kgs for 4 crew
-			cost = 50 //FIXME
-
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _Sabatier
-			}
-		}
-	}
-}
-
-// Patches to individual parts based on the general configs above
-@PART[ht2_moduleColumbus]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
-{
-	@MODULE[Configure]
-	{
-		@slots = 2 // just an example currently
 	}
 }
 
@@ -191,9 +34,24 @@
 
 @PART[ht2_moduleDestiny]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Configure]
+	MODULE
 	{
-		@slots = 2 // just an example currently
+		name = Configure
+		title = Modular Life Support
+
+		slots = 2 // just an example currently
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+
+		SETUP
+		{
+			name = None 2
+			desc = Empty slot 2
+		}
 	}
 }
 
@@ -206,41 +64,116 @@
 		desc = A treadmill designed to permit exercise in zero-g is included. The crew will love it.
 	}
 
-	@MODULE[Configure]
+	MODULE
 	{
-		@slots = 1 // just an example currently
+		name = Configure
+		title = Modular Life Support
+
+		slots = 1 // just an example currently
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
 	}
 }
 
 @PART[ht2_moduleKibo]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Configure]
+	MODULE
 	{
-		@slots = 3 // just an example currently
+		name = Configure
+		title = Modular Life Support
+
+		slots = 3 // just an example currently
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+
+		SETUP
+		{
+			name = None 2
+			desc = Empty slot 2
+		}
+
+		SETUP
+		{
+			name = None 3
+			desc = Empty slot 3
+		}
 	}
 }
 
 @PART[ht2_moduleQuest]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Configure]
+	MODULE
 	{
-		@slots = 1 // just an example currently
+		name = Configure
+		title = Modular Life Support
+
+		slots = 1 // just an example currently
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
 	}
 }
 
 @PART[ht2_moduleUnity]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Configure]
+	MODULE
 	{
-		@slots = 2 // just an example currently
+		name = Configure
+		title = Modular Life Support
+
+		slots = 2 // just an example currently
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+
+		SETUP
+		{
+			name = None 2
+			desc = Empty slot 2
+		}
 	}
 }
 
 @PART[ht2_moduleLabNode]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	@MODULE[Configure]
+	MODULE
 	{
-		@slots = 3 // just an example currently
+		name = Configure
+		title = Modular Life Support
+
+		slots = 3 // just an example currently
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+
+		SETUP
+		{
+			name = None 2
+			desc = Empty slot 2
+		}
+
+		SETUP
+		{
+			name = None 3
+			desc = Empty slot 3
+		}
 	}
 }
 
@@ -344,5 +277,168 @@
 	{
 		%volume = 15
 		%surface = 53
+	}
+}
+
+// Defines the Life Support equipment that exists on ISS for all parts
+@PART[ht2_moduleColumbus|ht2_moduleDestiny|ht2_moduleHarmony|ht2_moduleKibo|ht2_moduleQuest|ht2_moduleUnity|ht2_moduleLabNode]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _VacScrubber
+		title = Vacuum Scrubber
+		// 1 capacity = 1 crew output
+		capacity = 6
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		// 1 capacity = 70 m^2
+		capacity = 15
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControlOxygen
+		title = O2 Pressure Controller
+		// 1 capacity = 70 m^2
+		capacity = 15
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		// 1 capacity = 1 crew output
+		capacity = 6
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterElectrolysis
+		title = Water electrolysis
+		// 1 capacity >= 1 crew output
+		capacity = 4
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _Sabatier
+		title = Sabatier process
+		// 1 capacity >= 3 crew output CO2
+		capacity = 1
+		running = true
+	}
+
+	processConfigureExclude = true
+	@MODULE[Configure]
+	{
+
+		SETUP
+		{
+			name = Vacuum Scrubber
+			desc = A dual-bed vacuum-exposing regenerative scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere. Can work indefinitely. Can support a crew of 6.
+			tech = basicLifeSupport
+			mass = 0.2 //FIXME
+			cost = 25 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _VacScrubber
+			}
+		}
+
+		SETUP
+		{
+			name = N2 Pressure Control
+			desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+			tech = earlyLifeSupport
+			mass = 0.05 //FIXME
+			cost = 25 //FIXME
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _PressureControl
+			}
+		}
+
+		SETUP
+		{
+			name = O2 Pressure Control
+			desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
+			tech = earlyLifeSupport
+			mass = 0.01 //FIXME
+			cost = 25 //FIXME
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _PressureControlOxygen
+			}
+		}
+
+		SETUP
+		{
+			name = Water Recycler
+			desc = Filter impurities out of <b>WasteWater</b>. Can support a crew of 6.
+			tech = advancedLifeSupport
+			mass = 1.113 //  Using ISS urine processing system since that's our only wastewater generator, 742kg for 4 crew
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterRecycler
+			}
+		}
+
+		SETUP
+		{
+			name = Water Electrolysis
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components. Can support a crew of 4.
+			tech = longTermLifeSupport
+			mass = 0.676 // ISS OGS is 676 kgs for 4 crew
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterElectrolysis
+			}
+		}
+
+		SETUP
+		{
+			name = Sabatier Process
+			desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>. Can handle CO2 from 3 crew members.
+			tech = advancedLifeSupport
+			mass = 0.247 //  ISS CRS is 329 kgs for 4 crew
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _Sabatier
+			}
+		}
 	}
 }

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -1,0 +1,321 @@
+// Defines the Life Support equipment that exists on ISS for all parts
+@PART[ht2_moduleColumbus|ht2_moduleDestiny|ht2_moduleHarmony|ht2_moduleKibo|ht2_moduleQuest|ht2_moduleUnity]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _VacScrubber
+		title = Vacuum Scrubber
+		// 1 capacity = 1 crew output
+		capacity = 3
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControl
+		title = N2 Pressure Controller
+		// 1 capacity = 70 m^2
+		capacity = 3
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _PressureControlOxygen
+		title = O2 Pressure Controller
+		// 1 capacity = 70 m^2
+		capacity = 3
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water Recycler
+		// 1 capacity = 1 crew output
+		capacity = 6
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterElectrolysis
+		title = Water electrolysis
+		// 1 capacity >= 1 crew output
+		capacity = 4
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _Sabatier
+		title = Sabatier process
+		// Not sure about rates
+		capacity = 1
+		running = true
+	}
+
+	processConfigureExclude = true
+	MODULE
+	{
+		name = Configure
+		title = Module Life Support
+		slots = 1
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+
+		SETUP
+		{
+			name = Vacuum Scrubber
+			desc = A dual-bed vacuum-exposing regenerative scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere. Can work indefinitely. Can support a crew of 3.
+			tech = basicLifeSupport
+			mass = 0.2 //FIXME
+			cost = 25 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _VacScrubber
+			}
+		}
+
+		SETUP
+		{
+			name = N2 Pressure Control
+			desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
+			tech = earlyLifeSupport
+			mass = 0.05 //FIXME
+			cost = 25 //FIXME
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _PressureControl
+			}
+		}
+
+		SETUP
+		{
+			name = O2 Pressure Control
+			desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
+			tech = earlyLifeSupport
+			mass = 0.01 //FIXME
+			cost = 25 //FIXME
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _PressureControlOxygen
+			}
+		}
+
+		SETUP
+		{
+			name = Water Recycler
+			desc = Filter impurities out of <b>WasteWater</b>. Can support a crew of 6.
+			tech = advancedLifeSupport
+			mass = 1.113 //  Using ISS urine processing system since that's our only wastewater generator, 742kg for 4 crew
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterRecycler
+			}
+		}
+
+		SETUP
+		{
+			name = Water Electrolysis
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components. Can support a crew of 4.
+			tech = longTermLifeSupport
+			mass = 0.676 // ISS OGS is 676 kgs for 4 crew
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterElectrolysis
+			}
+		}
+
+		SETUP
+		{
+			name = Sabatier Process
+			desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>.
+			tech = advancedLifeSupport
+			mass = 0.329 //  ISS CRS is 329 kgs for 4 crew
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _Sabatier
+			}
+		}
+	}
+}
+
+// Patches to individual parts based on the general configs above
+@PART[ht2_moduleColumbus]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Configure]
+	{
+		@slots = 2 // just an example currently
+	}
+}
+
+@PART[ht2_moduleDestiny]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Configure]
+	{
+		@slots = 2 // just an example currently
+	}
+}
+
+@PART[ht2_moduleHarmony]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = Comfort
+		bonus = exercise
+		desc = A treadmill designed to permit exercise in zero-g is included. The crew will love it.
+	}
+
+	@MODULE[Configure]
+	{
+		@slots = 1 // just an example currently
+	}
+}
+
+@PART[ht2_moduleKibo]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Configure]
+	{
+		@slots = 3 // just an example currently
+	}
+}
+
+@PART[ht2_moduleQuest]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Configure]
+	{
+		@slots = 1 // just an example currently
+	}
+}
+
+@PART[ht2_moduleUnity]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Configure]
+	{
+		@slots = 2 // just an example currently
+	}
+}
+
+// ============================================================================
+// volume/surface configs
+// ============================================================================
+
+@PART[ht2_MPLM]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 31
+		%surface = 100.365
+	}
+}
+
+@PART[ht2_moduleColumbus]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 50
+		%surface = 129
+	}
+}
+
+@PART[ht2_moduleCupola]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 10
+		%surface = 21 // Guess
+	}
+}
+
+@PART[ht2_moduleDestiny]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 53
+		%surface = 138
+	}
+}
+
+@PART[ht2_moduleHarmony]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 70
+		%surface = 130
+	}
+}
+
+@PART[ht2_moduleJEMlogistics]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 34
+		%surface = 88
+	}
+}
+
+@PART[ht2_moduleKibo]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 85
+		%surface = 185
+	}
+}
+
+@PART[ht2_moduleQuest]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 20
+		%surface = 50 // Guess
+	}
+}
+
+@PART[ht2_moduleUnity]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 45
+		%surface = 111
+	}
+}
+
+@PART[ht2_MPLM_half]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 15
+		%surface = 53
+	}
+}

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -128,7 +128,7 @@
 {
 	@MODULE[Habitat]
 	{
-		%volume = 53
+		%volume = 98
 		%surface = 138
 	}
 }
@@ -139,15 +139,6 @@
 	{
 		%volume = 70
 		%surface = 130
-	}
-}
-
-@PART[ht2_moduleJEMlogistics]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
-{
-	@MODULE[Habitat]
-	{
-		%volume = 34
-		%surface = 88
 	}
 }
 
@@ -164,7 +155,7 @@
 {
 	@MODULE[Habitat]
 	{
-		%volume = 20
+		%volume = 34
 		%surface = 50 // Guess
 	}
 }
@@ -173,7 +164,7 @@
 {
 	@MODULE[Habitat]
 	{
-		%volume = 45
+		%volume = 34
 		%surface = 111
 	}
 }

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -142,6 +142,15 @@
 	}
 }
 
+@PART[ht2_moduleJEMlogistics]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 34
+		%surface = 88
+	}
+}
+
 @PART[ht2_moduleKibo]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat]

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -1,5 +1,5 @@
 // Defines the Life Support equipment that exists on ISS for all parts
-@PART[ht2_moduleColumbus|ht2_moduleDestiny|ht2_moduleHarmony|ht2_moduleKibo|ht2_moduleQuest|ht2_moduleUnity]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[ht2_moduleColumbus|ht2_moduleDestiny|ht2_moduleHarmony|ht2_moduleKibo|ht2_moduleQuest|ht2_moduleUnity|ht2_moduleLabNode]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
 	MODULE
 	{
@@ -236,6 +236,14 @@
 	}
 }
 
+@PART[ht2_moduleLabNode]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+	@MODULE[Configure]
+	{
+		@slots = 3 // just an example currently
+	}
+}
+
 // ============================================================================
 // volume/surface configs
 // ============================================================================
@@ -318,6 +326,15 @@
 	{
 		%volume = 45
 		%surface = 111
+	}
+}
+
+@PART[ht2_moduleLabNode]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 74
+		%surface = 140
 	}
 }
 

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -259,7 +259,7 @@
 		running = true
 	}
 
-	@MODULE[Configure]:HAS[@slots[>0]]
+	@MODULE[Configure]:HAS[#slots[>0]]
 	{
 		SETUP
 		{
@@ -268,7 +268,7 @@
 		}
 	}
 
-	@MODULE[Configure]:HAS[@slots[>1]]
+	@MODULE[Configure]:HAS[#slots[>1]]
 	{
 		SETUP
 		{
@@ -277,7 +277,7 @@
 		}
 	}
 
-	@MODULE[Configure]:HAS[@slots[>2]]
+	@MODULE[Configure]:HAS[#slots[>2]]
 	{
 		SETUP
 		{

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -7,7 +7,7 @@
 		resource = _VacScrubber
 		title = Vacuum Scrubber
 		// 1 capacity = 1 crew output
-		capacity = 3
+		capacity = 6
 		running = true
 	}
 
@@ -17,7 +17,7 @@
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		// 1 capacity = 70 m^2
-		capacity = 3
+		capacity = 15
 		running = true
 	}
 
@@ -27,7 +27,7 @@
 		resource = _PressureControlOxygen
 		title = O2 Pressure Controller
 		// 1 capacity = 70 m^2
-		capacity = 3
+		capacity = 15
 		running = true
 	}
 
@@ -56,7 +56,7 @@
 		name = ProcessController
 		resource = _Sabatier
 		title = Sabatier process
-		// Not sure about rates
+		// 1 capacity >= 3 crew output CO2
 		capacity = 1
 		running = true
 	}
@@ -77,7 +77,7 @@
 		SETUP
 		{
 			name = Vacuum Scrubber
-			desc = A dual-bed vacuum-exposing regenerative scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere. Can work indefinitely. Can support a crew of 3.
+			desc = A dual-bed vacuum-exposing regenerative scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere. Can work indefinitely. Can support a crew of 6.
 			tech = basicLifeSupport
 			mass = 0.2 //FIXME
 			cost = 25 //FIXME
@@ -155,7 +155,7 @@
 		SETUP
 		{
 			name = Sabatier Process
-			desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>.
+			desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>. Can handle CO2 from 3 crew members.
 			tech = advancedLifeSupport
 			mass = 0.329 //  ISS CRS is 329 kgs for 4 crew
 			cost = 50 //FIXME

--- a/GameData/KerbalismConfig/System/Misc.cfg
+++ b/GameData/KerbalismConfig/System/Misc.cfg
@@ -2,10 +2,21 @@
 // Stock panel module work correctly at arbitrary warp speed and EC capacity
 // ============================================================================
 
-@PART[*]:HAS[@MODULE[ModuleDeployableSolarPanel]]:AFTER[zzzKerbalism]
+@PART[*]:HAS[@MODULE[ModuleDeployableSolarPanel]]:FOR[KerbalismDefault]
 {
-  MODULE
+  // duplicate every ModuleDeployableSolarPanel
+  // Some parts may use multiple MDSP modules,
+  // so we have to add a SolarPanelFixer module each of them
+  +MODULE[ModuleDeployableSolarPanel],*
   {
+    // delete all values
+    -* = delete
+    // delete all possible nodes
+    -powerCurve {}
+    -temperatureEfficCurve {}
+    -timeEfficCurve {}
+    -UPGRADES {}
+    // rename the module to SolarPanelFixer
     name = SolarPanelFixer
   }
 }


### PR DESCRIPTION
Adds modular slots to HabTech2 modules that can be configured in the VAB with different life support equipment available on ISS, so simulate that equipment has moved around over the years in orbit