### PR TITLE
Make film4 principia-friendly

### DIFF
--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
@@ -569,3 +569,13 @@ KERBALISM_EXPERIMENT_VALUES
 		IncludeExperiment = RP0RPWS2
 	}
 }
+
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Principia]
+{
+	@RP0photos4 //Hubble Space Telescope
+	{
+		// stock 0.001 max eccentricity isn't practical with principia
+		@requirements ^= /OrbitMaxEccentricity:[^,]*/OrbitMaxEccentricity:0.005/
+	}
+}
+


### PR DESCRIPTION
There's been some discussion that maybe the near-zero eccentricity requirement doesn't make sense at all for a Hubble stand-in, but in the meantime, this will make it possible to run the experiment under principia without 20 years of constant manual station keeping

Oddity: the default 0.001 is rendered in-game as 0.0; this 0.005 gets rendered as 0.01. Might be better to make it _actually_ 0.01 to avoid player confusion, but 0.005 was comfortably enough in my experience, doubling it might be too much 