### PR TITLE
Add full support for NFE reactors

### DIFF
--- a/GameData/KerbalismConfig/Support/NearFuture.cfg
+++ b/GameData/KerbalismConfig/Support/NearFuture.cfg
@@ -26,6 +26,14 @@ Profile
 		refill_message = $VESSEL Enriched Uranium storage refilled@<i>Nuclear Reactors back online</i>
 	}
 
+	Supply
+	{
+		resource = UraniumNitride
+		low_message = Uranium Nitride is almost depleted on $VESSEL@<i>Nuclear Reactors will shut down soon</i>
+		empty_message = There is no more Uranium Nitride on $VESSEL@<i>Nuclear Reactors have shut down</i>
+		refill_message = $VESSEL Uranium Nitride storage refilled@<i>Nuclear Reactors back online</i>
+	}
+
 	Process
 	{
 		name = uraninite centrifuge
@@ -55,7 +63,80 @@ Profile
 		output = DepletedFuel@0.00000003125
 		output = XenonGas@0.000000015625
 		output = ElectricCharge@10
-		dump_valve = XenonGas&DepletedFuel,XenonGas,DepletedFuel
+		dump_valve = XenonGas
+	}
+
+	//Since fuel consumption varies significantly, create a process for each reactor
+	Process
+	{
+		name = RAPID-L Fission Reactor
+		modifier = _RAPIDLreactor
+		input = UraniumNitride@0.000000138654
+		output = DepletedFuel@0.00000013188
+		output = ElectricCharge@200
+	}
+
+	Process
+	{
+		name = SNAP-50 Fission Reactor
+		modifier = _SNAP50reactor
+		input = UraniumNitride@0.000000332725
+		output = DepletedFuel@0.0000004337254
+		output = ElectricCharge@300
+	}
+
+	Process
+	{
+		name = TOPAZ-II Fission Reactor
+		modifier = _TOPAZIIreactor
+		input = EnrichedUranium@0.000000019496
+		output = DepletedFuel@0.000000019496
+		output = ElectricCharge@6
+	}
+
+	Process
+	{
+		name = TOPAZ-I Fission Reactor
+		modifier = _TOPAZIreactor
+		input = EnrichedUranium@0.000000072213
+		output = DepletedFuel@0.000000072213
+		output = ElectricCharge@5
+	}
+
+	Process
+	{
+		name = BES-5 Fission Reactor
+		modifier = _BES5reactor
+		input = EnrichedUranium@0.00000026376
+		output = DepletedFuel@0.00000026376
+		output = ElectricCharge@3
+	}
+
+	Process
+	{
+		name = Kilopower Fission Reactor
+		modifier = _Kilopowerreactor
+		input = EnrichedUranium@0.000000001055
+		output = DepletedFuel@0.000000001055
+		output = ElectricCharge@10
+	}
+
+	Process
+	{
+		name = SAFE-400 Fission Reactor
+		modifier = _SAFE400reactor
+		input = UraniumNitride@0.000000020682
+		output = DepletedFuel@0.000000026596
+		output = ElectricCharge@100
+	}
+
+	Process
+	{
+		name = SNAP-10 Fission Reactor
+		modifier = _SNAP10reactor
+		input = EnrichedUranium@0.000000008592
+		output = DepletedFuel@0.000000008592
+		output = ElectricCharge@0.59
 	}
 }
 
@@ -162,29 +243,25 @@ Profile
 	// Note: 1000 mrem is 1 rad
 	// Note: Assume that shielding improves for larger reactors, and thus radiation is constant for all reactor types
 
-@PART[*]:HAS[@MODULE[FissionGenerator],@MODULE[FissionReactor]]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[*]:HAS[@MODULE[*Fission*]]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
-	MODULE
-	{
-		name = ProcessController
-		resource = _Nukereactor
-		title = Fission reactor
-		capacity = #$../MODULE[FissionGenerator]/PowerGeneration$
-		// capacity=1 means 10kW
-		@capacity /= 10
-	}
-
+	//Kill NFE/SystemHeat modules (sadly, they are not compatible)
 	!MODULE[FissionGenerator],* {}
 	!MODULE[FissionReactor],* {}
 	!MODULE[ModuleCoreHeatNoCatchup],* {}
 	!MODULE[ModuleUpdateOverride],* {}
 
+	!MODULE[ModuleSystemHeat] {}
+	!MODULE[ModuleSystemHeatFissionReactor] {}
+
+	//Add a radiation emitter
 	MODULE:NEEDS[FeatureRadiation]
 	{
 		name = Emitter
 		radiation = 0.000003 // rad/s
 	}
 
+	//Add reliability, if we ever use that (this should probably be tuned per-reactor)
 	MODULE:NEEDS[FeatureReliability]
 	{
 		name = Reliability
@@ -197,6 +274,104 @@ Profile
 		extra_mass = 1.0
 	}
 }
+
+//Assign processes to their reactors
+//RAPID-L
+@PART[reactor-25]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _RAPIDLreactor
+		title = RAPID-L Fission Reactor
+		capacity = 1
+	}
+}
+
+//SNAP-50
+@PART[RO-reactor-snap50]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _SNAP50reactor
+		title = SNAP-50 Fission Reactor
+		capacity = 1
+	}
+}
+
+//TOPAZ-II
+@PART[reactor-125]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _TOPAZIIreactor
+		title = TOPAZ-II Fission Reactor
+		capacity = 1
+	}
+}
+
+//TOPAZ-I
+@PART[RO-reactor-TOPAZI]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _TOPAZIreactor
+		title = TOPAZ-I Fission Reactor
+		capacity = 1
+	}
+}
+
+//BES-5
+@PART[RO-reactor-BES5]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _BES5reactor
+		title = BES-5 Fission Reactor
+		capacity = 1
+	}
+}
+
+//Kilopower
+@PART[RO-reactor-kilopower]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _Kilopowerreactor
+		title = Kilopower Fission Reactor
+		capacity = 1
+	}
+}
+
+//SAFE-400
+@PART[reactor-0625]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _SAFE400reactor
+		title = SAFE-400 Fission Reactor
+		capacity = 1
+	}
+}
+
+//SNAP-10
+@PART[RO-reactor-snap10a]:AFTER[RealismOverhaul]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _SNAP10reactor
+		title = SNAP-10 Fission Reactor
+		capacity = 1
+	}
+}
+
 
 // ============================================================================
 // Add Uraninite centrifuge and Breeder reactor to ISRU chemical plants and the NearFutureElectrical Nuclear Recycler
@@ -435,6 +610,62 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
 {
 	name = _Nukereactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _RAPIDLreactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _SNAP50reactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _TOPAZIIreactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _TOPAZIreactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _BES5reactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _Kilopowerreactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _SAFE400reactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _SNAP10reactor
 	density = 0.0
 	isVisible = false
 }


### PR DESCRIPTION
Add full support for NFE fission reactors. Since fuel burnup varies greatly among reactors, create and assign processes specific for each reactor (as suggested by Got). Also make patches compatible with just NFE, and NFE+SystemHeat.

needs https://github.com/KSP-RO/RealismOverhaul/pull/2665
closes https://github.com/KSP-RO/ROKerbalism/pull/82