### PR TITLE
Add config tool for resources

### DIFF
--- a/GameData/KerbalismConfig/ConfigTool.cfg
+++ b/GameData/KerbalismConfig/ConfigTool.cfg
@@ -1,24 +1,42 @@
 @PART:HAS[@ROKConfigTool]:LAST
 {
 	//	##############################
+	//	Resources that are handled
+	//	##############################
+	//	Food
+	//	Water
+	//	Oxygen
+	//	Waste
+	//	Waste Water
+	//
+	//	LiOH if wanted
+	//	KO2 if wanted
+	//	CO2 tanks for Vacuum scrubber if wanted
+
+	//	##############################
 	//	Values that can be set:
 	//	##############################
+	//	Crew = int - Defaults to CrewCapacity, number fo crewmembers
+	//	Days = int - Number of days of supplies
 	//	Scrubber = LiOH, KO2, Vacuum
-	//	LOXGOX = True - Oxygen provided by LOX to GOX converter
-	//	FUELCELL = True - Water provided by Fuel cells
+	//	OxygenProduction = True - Oxygen provided by LOX to GOX converter or Electrolyzer
+	//	WaterProduction = True - Water provided by Fuel cells or other process
 	//	AppendDescription = True - Adds "Supports X crew for Y days." to description
+	//	ReuseVolume = True - Do not add volume to the MFT
 
 	// Default consumption rates and values
 	// Rates per kerbal-day
 	@ROKConfigTool
 	{
+		// Default values / Set up variables
 		&Crew = #$/CrewCapacity$
 		&Days = 0
 		Volume = 0
+		Waste = 0
+		// Rates
 		Food = 5.84928
 		Oxygen = 591.84
 		Water = 3.87072
-		Waste = 0
 	}
 
 	@ROKConfigTool:HAS[#Scrubber[LiOH]]
@@ -45,36 +63,42 @@
 		@KO2Waste *= #$Crew$
 		@KO2Waste *= #$Days$
 		@Waste += #$KO2Waste$
-		// Some oxygen returned, reduce effective oxygen consumption
-		@Oxygen *= 
+		// More oxygen than consumed is returned, set flag to true
+		%OxygenProduction = True
 	}
 
 	@ROKConfigTool:HAS[#Scrubber[Vacuum]]
 	{
-		CO2 = 
+		CO2 = 591.84
+		@CO2 *= 1 // Store 1 days worth of CO2
 		@CO2 *= #$Crew$
-		@Volume += #$CO2$
+		// CO2 is a gas, divide tank volume by 1000
+		CO2Volume = #$CO2$
+		@CO2Volume /= 1000
+		@Volume += #$CO2Volume$
 	}
 
-	@ROKConfigTool:HAS[#LOXGOX[?rue]]
+	@ROKConfigTool:HAS[#OxygenProduction[?rue]]
 	{
-		@Oxygen *= 
+		// Oxygen production exists, limit storage to 1 day
+		@Oxygen *= 1
 		@Oxygen *= #$Crew$
 	}
 
-	@ROKConfigTool:HAS[~LOXGOX[?rue]]
+	@ROKConfigTool:HAS[~OxygenProduction[?rue]]
 	{
 		@Oxygen *= #$Crew$
 		@Oxygen *= #$Days$
 	}
 
-	@ROKConfigTool:HAS[#FUELCELL[?rue]]
+	@ROKConfigTool:HAS[#WaterProduction[?rue]]
 	{
-		@Water *= 
+		// Water production exists, limit storage to 1 day
+		@Water *= 1
 		@Water *= #$Crew$
 	}
 
-	@ROKConfigTool:HAS[~FUELCELL[?rue]]
+	@ROKConfigTool:HAS[~WaterProduction[?rue]]
 	{
 		@Water *= #$Crew$
 		@Water *= #$Days$
@@ -84,21 +108,36 @@
 	{
 		@Food *= #$Crew$
 		@Food *= #$Days$
-		@WasteWater = 
 		@Volume += #$Food$
-		@Volume += #$Oxygen$
+
+		WasteWater = 3.87072
+		@WasteWater *= 1 //Store 1 days worth of waste water
+		@WasteWater *= #$Crew$
+		@Volume += #$WasteWater$
+
+		// Oxygen is a gas, divide needed tank volume by 1000
+		OxygenVolume = #$Oxygen$
+		@OxygenVolume /= 1000
+		@Volume += #$OxygenVolume$
+
 		@Volume += #$Water$
 		@Volume += #$Waste$
 	}
 }
 
-@PART:HAS[@ROKConfigTool:HAS[~Food[0]]]:LAST
+@PART:HAS[@ROKConfigTool:HAS[~Food[0],~ReuseVolume[?rue]]]:LAST
 {
 	%MODULE[ModuleFuelTanks]
 	{
 		&volume = 0
 		@volume += #$/ROKConfigTool/Volume$
+	}
+}
 
+@PART:HAS[@ROKConfigTool:HAS[~Food[0]]]:LAST
+{
+	@MODULE[ModuleFuelTanks]
+	{
 		TANK
 		{
 			name = Food

--- a/GameData/KerbalismConfig/ConfigTool.cfg
+++ b/GameData/KerbalismConfig/ConfigTool.cfg
@@ -24,71 +24,71 @@
 	@ROKConfigTool:HAS[#Scrubber[LiOH]]
 	{
 		LiOH = 
-		LiOH *= #$Crew$
-		LiOH *= #$Days$
-		Volume += #$LiOH$
+		@LiOH *= #$Crew$
+		@LiOH *= #$Days$
+		@Volume += #$LiOH$
 
 		LiOHWaste = 
-		LiOHWaste *= #$Crew$
-		LiOHWaste *= #$Days$
-		Waste += #$LiOHWaste$
+		@LiOHWaste *= #$Crew$
+		@LiOHWaste *= #$Days$
+		@Waste += #$LiOHWaste$
 	}
 
 	@ROKConfigTool:HAS[#Scrubber[KO2]]
 	{
 		KO2 = 
-		KO2 *= #$Crew$
-		KO2 *= #$Days$
-		Volume += #$KO2$
+		@KO2 *= #$Crew$
+		@KO2 *= #$Days$
+		@Volume += #$KO2$
 
 		KO2Waste = 
-		KO2Waste = #$Crew$
-		KO2Waste = #$Days$
-		Waste += #$KO2Waste$
+		@KO2Waste *= #$Crew$
+		@KO2Waste *= #$Days$
+		@Waste += #$KO2Waste$
 		// Some oxygen returned, reduce effective oxygen consumption
-		Oxygen *= 
+		@Oxygen *= 
 	}
 
 	@ROKConfigTool:HAS[#Scrubber[Vacuum]]
 	{
 		CO2 = 
-		CO2 *= #$Crew$
-		Volume += #$CO2$
+		@CO2 *= #$Crew$
+		@Volume += #$CO2$
 	}
 
 	@ROKConfigTool:HAS[#LOXGOX[?rue]]
 	{
-		Oxygen *= 
-		Oxygen *= #$Crew$
+		@Oxygen *= 
+		@Oxygen *= #$Crew$
 	}
 
 	@ROKConfigTool:HAS[~LOXGOX[?rue]]
 	{
-		Oxygen *= #$Crew$
-		Oxygen *= #$Days$
+		@Oxygen *= #$Crew$
+		@Oxygen *= #$Days$
 	}
 
 	@ROKConfigTool:HAS[#FUELCELL[?rue]]
 	{
-		Water *= 
-		Water *= #$Crew$
+		@Water *= 
+		@Water *= #$Crew$
 	}
 
 	@ROKConfigTool:HAS[~FUELCELL[?rue]]
 	{
-		Water *= #$Crew$
-		Water *= #$Days$
+		@Water *= #$Crew$
+		@Water *= #$Days$
 	}
 
 	@ROKConfigTool
 	{
-		Food *= #$Crew$
-		Food *= #$Days$
-		WasteWater = 
-		Volume += #$Food$
-		Volume += #$Oxygen$
-		Volume += #$Water$
-		Volume += #$Waste$
+		@Food *= #$Crew$
+		@Food *= #$Days$
+		@WasteWater = 
+		@Volume += #$Food$
+		@Volume += #$Oxygen$
+		@Volume += #$Water$
+		@Volume += #$Waste$
 	}
 }
 
@@ -97,7 +97,7 @@
 	%MODULE[ModuleFuelTanks]
 	{
 		&volume = 0
-		volume += #$/ROKConfigTool/Volume$
+		@volume += #$/ROKConfigTool/Volume$
 
 		TANK
 		{

--- a/GameData/KerbalismConfig/ConfigTool.cfg
+++ b/GameData/KerbalismConfig/ConfigTool.cfg
@@ -41,12 +41,12 @@
 
 	@ROKConfigTool:HAS[#Scrubber[LiOH]]
 	{
-		LiOH = 
+		LiOH = 1.027296
 		@LiOH *= #$Crew$
 		@LiOH *= #$Days$
 		@Volume += #$LiOH$
 
-		LiOHWaste = 
+		LiOHWaste = 1.397088
 		@LiOHWaste *= #$Crew$
 		@LiOHWaste *= #$Days$
 		@Waste += #$LiOHWaste$
@@ -54,12 +54,12 @@
 
 	@ROKConfigTool:HAS[#Scrubber[KO2]]
 	{
-		KO2 = 
+		KO2 = 1.155168
 		@KO2 *= #$Crew$
 		@KO2 *= #$Days$
 		@Volume += #$KO2$
 
-		KO2Waste = 
+		KO2Waste = 1.80225
 		@KO2Waste *= #$Crew$
 		@KO2Waste *= #$Days$
 		@Waste += #$KO2Waste$

--- a/GameData/KerbalismConfig/ConfigTool.cfg
+++ b/GameData/KerbalismConfig/ConfigTool.cfg
@@ -136,6 +136,45 @@
 	}
 }
 
+@PART:HAS[@ROKConfigTool:HAS[#LiOH]]:LAST
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = #$/ROKConfigTool/LiOH$
+			maxAmount = #$/ROKConfigTool/LiOH$
+		}
+	}
+}
+
+@PART:HAS[@ROKConfigTool:HAS[#KO2]]:LAST
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		TANK
+		{
+			name = PotassiumSuperoxide
+			amount = #$/ROKConfigTool/KO2$
+			maxAmount = #$/ROKConfigTool/KO2$
+		}
+	}
+}
+
+@PART:HAS[@ROKConfigTool:HAS[#CO2]]:LAST
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		TANK
+		{
+			name = CarbonDioxide
+			amount = 0
+			maxAmount = #$/ROKConfigTool/CO2$
+		}
+	}
+}
+
 @PART:HAS[@ROKConfigTool:HAS[#AppendDescription[?rue]]]:LAST
 {
 	@description = #$description$ Supports a crew of $/ROKConfigTool/Crew$ for $/ROKConfigTool/Days$ days.

--- a/GameData/KerbalismConfig/ConfigTool.cfg
+++ b/GameData/KerbalismConfig/ConfigTool.cfg
@@ -1,0 +1,148 @@
+@PART:HAS[@ROKConfigTool]:LAST
+{
+	//	##############################
+	//	Values that can be set:
+	//	##############################
+	//	Scrubber = LiOH, KO2, Vacuum
+	//	LOXGOX = True - Oxygen provided by LOX to GOX converter
+	//	FUELCELL = True - Water provided by Fuel cells
+	//	AppendDescription = True - Adds "Supports X crew for Y days." to description
+
+	// Default consumption rates and values
+	// Rates per kerbal-day
+	@ROKConfigTool
+	{
+		&Crew = #$/CrewCapacity$
+		&Days = 0
+		Volume = 0
+		Food = 5.84928
+		Oxygen = 591.84
+		Water = 3.87072
+		Waste = 0
+	}
+
+	@ROKConfigTool:HAS[#Scrubber[LiOH]]
+	{
+		LiOH = 
+		LiOH *= #$Crew$
+		LiOH *= #$Days$
+		Volume += #$LiOH$
+
+		LiOHWaste = 
+		LiOHWaste *= #$Crew$
+		LiOHWaste *= #$Days$
+		Waste += #$LiOHWaste$
+	}
+
+	@ROKConfigTool:HAS[#Scrubber[KO2]]
+	{
+		KO2 = 
+		KO2 *= #$Crew$
+		KO2 *= #$Days$
+		Volume += #$KO2$
+
+		KO2Waste = 
+		KO2Waste = #$Crew$
+		KO2Waste = #$Days$
+		Waste += #$KO2Waste$
+		// Some oxygen returned, reduce effective oxygen consumption
+		Oxygen *= 
+	}
+
+	@ROKConfigTool:HAS[#Scrubber[Vacuum]]
+	{
+		CO2 = 
+		CO2 *= #$Crew$
+		Volume += #$CO2$
+	}
+
+	@ROKConfigTool:HAS[#LOXGOX[?rue]]
+	{
+		Oxygen *= 
+		Oxygen *= #$Crew$
+	}
+
+	@ROKConfigTool:HAS[~LOXGOX[?rue]]
+	{
+		Oxygen *= #$Crew$
+		Oxygen *= #$Days$
+	}
+
+	@ROKConfigTool:HAS[#FUELCELL[?rue]]
+	{
+		Water *= 
+		Water *= #$Crew$
+	}
+
+	@ROKConfigTool:HAS[~FUELCELL[?rue]]
+	{
+		Water *= #$Crew$
+		Water *= #$Days$
+	}
+
+	@ROKConfigTool
+	{
+		Food *= #$Crew$
+		Food *= #$Days$
+		WasteWater = 
+		Volume += #$Food$
+		Volume += #$Oxygen$
+		Volume += #$Water$
+		Volume += #$Waste$
+	}
+}
+
+@PART:HAS[@ROKConfigTool:HAS[~Food[0]]]:LAST
+{
+	%MODULE[ModuleFuelTanks]
+	{
+		&volume = 0
+		volume += #$/ROKConfigTool/Volume$
+
+		TANK
+		{
+			name = Food
+			amount = #$/ROKConfigTool/Food$
+			maxAmount = #$/ROKConfigTool/Food$
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = #$/ROKConfigTool/Oxygen$
+			maxAmount = #$/ROKConfigTool/Oxygen$
+		}
+
+		TANK
+		{
+			name = Water
+			amount = #$/ROKConfigTool/Water$
+			maxAmount = #$/ROKConfigTool/Water$
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = #$/ROKConfigTool/Waste$
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = #$/ROKConfigTool/WasteWater$
+		}
+	}
+}
+
+@PART:HAS[@ROKConfigTool:HAS[#AppendDescription[?rue]]]:LAST
+{
+	@description = #$description$ Supports a crew of $/ROKConfigTool/Crew$ for $/ROKConfigTool/Days$ days.
+}
+
+// Cleanup
+@PART:HAS[@ROKConfigTool]:LAST
+{
+	!ROKConfigTool {}
+}


### PR DESCRIPTION
Adds a MM tool to configure life support resources based on crew-days wanted. Supports specifying what resources are generated on-board and should be kept at lower values