### PR TITLE
Gate Science Converter patches better

### DIFF
--- a/GameData/KerbalismConfig/System/Science/CrewScience/ScienceLabs.cfg
+++ b/GameData/KerbalismConfig/System/Science/CrewScience/ScienceLabs.cfg
@@ -1,5 +1,5 @@
 // add the Laboratory module and remove the stock module
-@PART[*]:HAS[@MODULE[ModuleScienceConverter]]:BEFORE[RP-0-Kerbalism]
+@PART[*]:HAS[@MODULE[ModuleScienceConverter],#CrewCapacity]:BEFORE[RP-0-Kerbalism]
 {
 	!MODULE[ModuleScienceConverter] {}
 


### PR DESCRIPTION
Gate Science converter patches to avoid running on parts with no crew capacity defined at runtime. Resolves BDB wetlabs causing MM errors because they do not define crew capacity at runtime.