### PR TITLE
Correct fuel cell fuel consumption

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -362,13 +362,24 @@ Supply
 	// Fuel Cells are based off of 1.0kW produced. For the process controller, we
 	// should be multiplying the capacity * the amount we want produced
 	// Eg. Apollo Fuel Cells were 1.42kW so the capacity = 1.42
+	// Sources:
+	// https://www.ibiblio.org/apollo/ApolloProjectOnline/Documents/SMA2A-03-BLOCK%20II%20Volume%201%2019691015/aoh-v1-2-06-eps.pdf
+	// https://history.nasa.gov/alsj/CSM13_Electrical_Power_Subsystem_pp99-116.pdf
+	// Apollo fuel cell was about 80% (hydrogen) efficient (it doesn't run stoich but we're ignoring that)
+	// Hydrogen has a LHV of 120 MJ/kg (LHV is probably appropriate for high temperature fuel cells)
+	// Liquid Hydrogen has a density of 0.07085 kg/L
+	// Therefore, we need 0.00011765 / 0.8 = 0.000147057 L/s of Lqd Hydrogen to generate 1 kW
+	// Liquid Oxygen has a density of 1.141 kg/L
+	// running stoich, we then need 0.00007247 L/s of Lqd Oxygen to match
+	// 0.03751 kg/hr LH2, 0.2977 kg/hr O2
+	// this will produce 0.33521 kg/hr / 3600 = 0.000093114 L/s of water
 	Process
 	{
 		name = fuel cell
 		modifier = _FuelCell
-		input = LqdOxygen@0.000134718
-		input = LqdHydrogen@0.000269436
-		output = Water@0.0001186
+		input = LqdOxygen@0.00007247
+		input = LqdHydrogen@0.000147057
+		output = Water@0.000093114
 		output = ElectricCharge@1.0
 		dump_valve = Water
 	}


### PR DESCRIPTION
Fuel cell values were previously wrong, operating at ~40% efficiency and violating the conservation of mass by producing much less water output than fuel input. Redoing the math based on numbers from the Apollo fuel cell, efficiency has been changed to 80% and stoichiometry redone to obey the conservation of mass.

This should solve issues with Apollo running out of power early, despite having historical J-class propellant loads.