### PR TITLE
Use subtract operator instead of just overriding, also Gemini

### DIFF
--- a/GameData/KerbalismConfig/Support/ROCapsules.cfg
+++ b/GameData/KerbalismConfig/Support/ROCapsules.cfg
@@ -54,6 +54,9 @@
 
 	@MODULE[ModuleFuelTanks]
 	{
+		@basemass -= 0.09686	//75.44 kg tanks, 15.42 kg LS resources, 6 kg LiOH
+		//we actually have more LS resources than this, because the reference is a 2-day mission and we're loaded for 14 days.
+
 		TANK
 		{
 			name = Food
@@ -63,14 +66,14 @@
 		TANK
 		{
 			name = Water
-			amount = 8
-			maxAmount = 8	// 1 day
+			amount = 6.8
+			maxAmount = 6.8	// 6.8 kg
 		}
 		TANK
 		{
 			name = Oxygen
-			amount = 1184
-			maxAmount = 1184	// 1 day
+			amount = 4503
+			maxAmount = 4503	// 6.35 kg
 		}
 		TANK
 		{
@@ -87,8 +90,8 @@
 		TANK
 		{
 			name = LithiumHydroxide
-			amount = 29
-			maxAmount = 29	// 14 days
+			amount = 24.6
+			maxAmount = 24.6	// 15 days
 		}
 	}
 }

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -34,7 +34,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 1.520  //Remove Climatization and LS power draw
+      @rate -= 0.033  //Remove Climatization and LS power draw
     }
   }
   // uses an EVA scrubber because x-15's life support was just a rudimentary
@@ -109,7 +109,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 0.475  //Remove Climatization and LS power draw
+      @rate -= 0.055  //Remove Climatization and LS power draw
     }
   }
   MODULE
@@ -140,7 +140,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 0.214  //Remove Climatization and LS power draw
+      @rate -= 0.035  //Remove Climatization and LS power draw
     }
   }
 
@@ -195,7 +195,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 0.650  //Remove Climatization and LS power draw
+      @rate -= 0.129  //Remove Climatization and LS power draw
     }
   }
 
@@ -283,7 +283,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 1.900  //Remove Climatization and LS power draw
+      @rate -= 0.187 //Remove Climatization and LS power draw
     }
   }
 }
@@ -373,7 +373,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 1.785  //Remove Climatization and LS power draw
+      @rate -= 0.199  //Remove Climatization and LS power draw
     }
   }
 }
@@ -397,7 +397,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 0.360  //Remove Climatization and LS power draw
+      @rate -= 0.181  //Remove Climatization and LS power draw
     }
   }
 
@@ -519,7 +519,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 0.327  //Remove Climatization and LS power draw
+      @rate -= 0.180  //Remove Climatization and LS power draw
     }
   }
 }
@@ -612,7 +612,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 1.65  //Remove Climatization and LS power draw
+      @rate -= 0.294  //Remove Climatization and LS power draw
     }
   }
 }
@@ -706,7 +706,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 1.520  //Remove Climatization and LS power draw
+      @rate -= 0.304  //Remove Climatization and LS power draw
     }
   }
 }
@@ -798,7 +798,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate -= 0.2  //Remove Climatization and LS power draw
+      @rate -= 0.202  //Remove Climatization and LS power draw
     }
   }
 }
@@ -897,7 +897,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 1.500  //Remove Climatization and LS power draw
+      @rate -= 0.674  //Remove Climatization and LS power draw
     }
   }
 
@@ -1080,7 +1080,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 0.600  //Remove Climatization and LS power draw
+      @rate -= 1.000  //Remove Climatization and LS power draw
     }
   }
 
@@ -1112,7 +1112,7 @@
   {
     @RESOURCE[ElectricCharge]
     {
-      @rate = 1.000  //Remove Climatization and LS power draw
+      @rate -= 1.000  //Remove Climatization and LS power draw
     }
   }
 


### PR DESCRIPTION
Adjust life support configs so life support draw is subtracted from capsule avionics draw, instead of just overwriting avionics draw with a new one (why did I even do that)

also configure stuff for the ROC-Gemini overhaul [here](https://github.com/KSP-RO/ROCapsules/pull/149)