### PR TITLE
Autodump water, oxygen

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -286,7 +286,7 @@ Supply
 		input = WasteAtmosphere@0.00453827  //765g per day
 		output = Oxygen@0.006851  //barely more than required
 		output = Waste@0.000020859375  //2403g per day
-		dump_valve = Oxygen, Waste, Oxygen&Waste
+		dump = true
 	}
 
 	// ISS has normal air pressure at 101.3kPa (14.7 psi)
@@ -381,7 +381,7 @@ Supply
 		input = LqdHydrogen@0.000147057
 		output = Water@0.000093114
 		output = ElectricCharge@1.0
-		dump_valve = Water
+		dump = true
 	}
 
 	// Based on current electrolysis rates where it takes 12.749kWh to make 1L of H


### PR DESCRIPTION
Set fuel cells to always dump water, and KO2 scrubbers to always dump oxygen.

Forgetting to set resource dumping is a major trap for new players, and this avoids any possible bugs with kerbalism forgetting to dump (if those haven't been fixed yet).

Although there are potentially niche scenarios in which the player would not want this to happen, breaking those are preferable to the fuel cell and KO2 scrubber not functioning as expected 99% of the time.