### PR TITLE
Fix buggy kerbalism fuel cells, and create new types

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -362,6 +362,22 @@ Supply
 	// Fuel Cells are based off of 1.0kW produced. For the process controller, we
 	// should be multiplying the capacity * the amount we want produced
 	// Eg. Apollo Fuel Cells were 1.42kW so the capacity = 1.42
+	
+	// Gemini Fuel cell
+	// Complete guess, based on Gemini fuel load
+	// 70% Hydrogen efficient (by LHV) (it doesn't run stoich but we're ignoring that)
+	Process
+	{
+		name = fuel cell gemini
+		modifier = _FuelCellGemini
+		input = LqdOxygen@0.00008282
+		input = LqdHydrogen@0.000168065
+		output = Water@0.000106416
+		output = ElectricCharge@1.0
+		dump = Water
+	}
+	
+	//Apollo Fuel cell
 	// Sources:
 	// https://www.ibiblio.org/apollo/ApolloProjectOnline/Documents/SMA2A-03-BLOCK%20II%20Volume%201%2019691015/aoh-v1-2-06-eps.pdf
 	// https://history.nasa.gov/alsj/CSM13_Electrical_Power_Subsystem_pp99-116.pdf
@@ -381,7 +397,37 @@ Supply
 		input = LqdHydrogen@0.000147057
 		output = Water@0.000093114
 		output = ElectricCharge@1.0
-		dump_valve = Water		//if this is removed and set to dump all instead, EC will also be dumped, resulting in excessive fuel usage
+		dump = Water
+	}
+	
+	//Soyuz-LOK Volna-20 Fuel cell
+	// source: http://www.astronautix.com/l/lokpao.html
+	// no good info, but 600 kg reactants for 500 hours suggests not very efficient
+	// same as Gemini (70% by LHV) I guess
+	Process
+	{
+		name = fuel cell volna20
+		modifier = _FuelCellVolna20
+		input = LqdOxygen@0.00008282
+		input = LqdHydrogen@0.000168065
+		output = Water@0.000106416
+		output = ElectricCharge@1.0
+		dump = Water
+	}
+	
+	//Space Shuttle fuel cells
+	// source: https://ntrs.nasa.gov/api/citations/20040010319/downloads/20040010319.pdf
+	// "over 70% efficient". Assuming that's using HHV to match modern conventions, not LHV.
+	// Guessing 75% efficient by HHV, which is 88.6% efficient by LHV
+	Process
+	{
+		name = fuel cell shuttle
+		modifier = _FuelCellShuttle
+		input = LqdOxygen@0.0000654357
+		input = LqdHydrogen@0.0001327828
+		output = Water@0.0000840758
+		output = ElectricCharge@1.0
+		dump = Water
 	}
 
 	// Based on current electrolysis rates where it takes 12.749kWh to make 1L of H
@@ -944,7 +990,7 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellGemini
 		title = Gemini Fuel Cell
 		capacity = 1
 		running = true
@@ -960,7 +1006,7 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellVolna20
 		title = Soyuz Fuel Cell
 		capacity = 1
 		running = true
@@ -968,7 +1014,7 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellShuttle
 		title = Shuttle Fuel Cell
 		capacity = 1
 		running = true
@@ -990,8 +1036,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Gemini Fuel Cell
+				id_field = resource
+				id_value = _FuelCellGemini
 			}
 		}
 
@@ -1005,8 +1051,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Apollo Fuel Cell
+				id_field = resource
+				id_value = _FuelCell
 			}
 		}
 
@@ -1020,8 +1066,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Soyuz Fuel Cell
+				id_field = resource
+				id_value = _FuelCellVolna20
 			}
 		}
 
@@ -1035,8 +1081,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Shuttle Fuel Cell
+				id_field = resource
+				id_value = _FuelCellShuttle
 			}
 		}
   	}
@@ -1054,7 +1100,7 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellGemini
 		title = Gemini Fuel Cell
 		capacity = 0.75
 		running = true
@@ -1070,7 +1116,7 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellShuttle
 		title = Shuttle Fuel Cell
 		capacity = 0.75
 		running = true
@@ -1092,8 +1138,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Gemini Fuel Cell
+				id_field = resource
+				id_value = _FuelCellGemini
 			}
 		}
 
@@ -1107,8 +1153,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Apollo Fuel Cell
+				id_field = resource
+				id_value = _FuelCell
 			}
 		}
 
@@ -1122,8 +1168,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Shuttle Fuel Cell
+				id_field = resource
+				id_value = _FuelCellShuttle
 			}
 		}
  	}
@@ -1141,7 +1187,7 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellGemini
 		title = Gemini Fuel Cell
 		capacity = 6
 		running = true
@@ -1157,7 +1203,7 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellShuttle
 		title = Shuttle Fuel Cell
 		capacity = 6
 		running = true
@@ -1179,8 +1225,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Gemini Fuel Cell
+				id_field = resource
+				id_value = _FuelCellGemini
 			}
 		}
 
@@ -1194,8 +1240,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Apollo Fuel Cell
+				id_field = resource
+				id_value = _FuelCell
 			}
 		}
 
@@ -1209,8 +1255,8 @@ Supply
 			MODULE
 			{
 				type = ProcessController
-				id_field = title
-				id_value = Shuttle Fuel Cell
+				id_field = resource
+				id_value = _FuelCellShuttle
 			}
 		}
   	}
@@ -1647,6 +1693,28 @@ RESOURCE_DEFINITION
   density = 0.0
   isVisible = false
 }
+
+RESOURCE_DEFINITION
+{
+  name = _FuelCellGemini
+  density = 0.0
+  isVisible = false
+}
+
+RESOURCE_DEFINITION
+{
+  name = _FuelCellVolna20
+  density = 0.0
+  isVisible = false
+}
+
+RESOURCE_DEFINITION
+{
+  name = _FuelCellShuttle
+  density = 0.0
+  isVisible = false
+}
+
 @PART:HAS[@MODULE[ProcessController]:HAS[#resource[_FuelCell]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
 {
 	@tags ^=:$:, fuel cell, lqdhydrogen, lqdoxygen, generator

--- a/GameData/KerbalismConfig/Support/DECQ_Buran.cfg
+++ b/GameData/KerbalismConfig/Support/DECQ_Buran.cfg
@@ -83,7 +83,7 @@
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellShuttle
 		title = Fuel Cell
 		capacity = 40 //Max continuous output
 		running = true
@@ -106,7 +106,7 @@
 			{
 				type = ProcessController
 				id_field = resource
-				id_value = _FuelCell
+				id_value = _FuelCellShuttle
 			}
 		}
 	}

--- a/GameData/KerbalismConfig/Support/SOCK.cfg
+++ b/GameData/KerbalismConfig/Support/SOCK.cfg
@@ -75,7 +75,7 @@
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellShuttle
 		title = Fuel Cell
 		capacity = 21 //Max continuous output
 		running = true
@@ -98,7 +98,7 @@
 			{
 				type = ProcessController
 				id_field = resource
-				id_value = _FuelCell
+				id_value = _FuelCellShuttle
 			}
 		}
 	}

--- a/GameData/KerbalismConfig/Support/SSS.cfg
+++ b/GameData/KerbalismConfig/Support/SSS.cfg
@@ -75,7 +75,7 @@
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellShuttle
 		title = Fuel Cell
 		capacity = 21 //Max continuous output
 		running = true
@@ -98,7 +98,7 @@
 			{
 				type = ProcessController
 				id_field = resource
-				id_value = _FuelCell
+				id_value = _FuelCellShuttle
 			}
 		}
 	}

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -244,7 +244,7 @@
 	MODULE
 	{
 		name = ProcessController
-		resource = _FuelCell
+		resource = _FuelCellVolna20
 		title = Fuel Cells 
 		capacity = 1.5
 		toggle = true
@@ -266,7 +266,7 @@
 			{
 				type = ProcessController
 				id_field = resource
-				id_value = _FuelCell
+				id_value = _FuelCellVolna20
 			}
 		}
 	}
@@ -294,7 +294,7 @@
   MODULE
   {
     name = ProcessController
-    resource = _FuelCell
+    resource = _FuelCellGemini
     title = Fuel Cells
     capacity = 4
     running = true
@@ -332,7 +332,7 @@
       {
         type = ProcessController
         id_field = resource
-        id_value = _FuelCell
+        id_value = _FuelCellGemini
       }
     }
 
@@ -529,7 +529,7 @@
   MODULE
   {
     name = ProcessController
-    resource = _FuelCell
+    resource = _FuelCellGemini
     title = Fuel Cells
     capacity = 2.2
     toggle = true
@@ -581,7 +581,7 @@
       {
         type = ProcessController
         id_field = resource
-        id_value = _FuelCell
+        id_value = _FuelCellGemini
       }
     }
     SETUP
@@ -1044,7 +1044,7 @@
   MODULE
   {
     name = ProcessController
-    resource = _FuelCell
+    resource = _FuelCellShuttle
     title = Fuel Cell
     capacity = 21 //https://science.ksc.nasa.gov/shuttle/technology/sts-newsref/sts-eps.html (21 kW continuous power)
     running = false
@@ -1063,7 +1063,7 @@
       {
         type = ProcessController
         id_field = resource
-        id_value = _FuelCell
+        id_value = _FuelCellShuttle
       }
     }
   }


### PR DESCRIPTION
Fix bugs with kerbalism fuel cells caused by multiple identical configs. 
Create unique processes for each config to resolve this bug, and also adjust their efficiency a bit to be more realistic. Gemini and Soyuz fuel cells are now less efficient than Apollo fuel cells, while Shuttle fuel cells are slightly more efficient. Finally, correctly tag fuel cells to always dump water, and _only_ water.

Tested, this appears to fix all fuel-cell related bugs that I am aware of, and also ensures a fuel cell will never fail to work due to a full water tank. Vessels in flight with fuel cells (both preset and configurable) will update to their new stats and continue to work.