### PR TITLE
Fix the habitat of the medium lander can

### DIFF
--- a/GameData/KerbalismConfig/System/Habitat.cfg
+++ b/GameData/KerbalismConfig/System/Habitat.cfg
@@ -172,7 +172,7 @@
 		%max_pressure = 0.35
 	}
 }
-@PART[LEM_ASCENT_STAGE|FASALM_AscentStage|MEMLanderSXT|MEMLander]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+@PART[LEM_ASCENT_STAGE|FASALM_AscentStage|MEMLanderSXT|MEMLander|landerCabinMedium]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat]
 	{


### PR DESCRIPTION
This is supposed to be balanced as a generic LEM equivalent, but didn't have its habitat volume set leaving it with 10m^3. (It is in the Parts.cfg list of LEMs.)