### PR TITLE
Add gas generator options to liquifier

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -645,6 +645,146 @@ Supply
 		input = ElectricCharge@0.08835372	// source: https://cordis.europa.eu/project/id/278177/reporting/pl 6.5kWh/kg
 		output = LqdHydrogen@0.00005329287227
 	}
+	
+	// ~same rate as oxygen converter I guess
+	// since heating up oxygen could be completely passive or completely active based on external temperature, we make 2 assumptions:
+	// 1. the external temperature is high enough that CH4 is always above its critical point (111K) (so that vaporization is free)
+	// 2. we have to bring the gaseous CH4 from external ambient temp to room temperature
+	// the EC consumption is therefore defined as the power needed to heat methane from external temp to internal temp (20� C)
+	// CH4 isochoric specific heat = ~2087 J/(Kg*K) for 0.02 g/s => 0.0417 W/K * 182 K = 7.60 W
+	Process
+	{
+		name = lch4 to ch4 converter
+		modifier = _LCH4Converter
+		input = LqdMethane@0.0000469913
+		input = ElectricCharge@0.00760
+		output = Methane@0.027894
+	}
+
+	// convention: same as vaporizer? (0.02 g/s)
+	// source: https://advancedtech.airliquide.com/markets-solutions/industry/turbo-brayton-small-scale-methane-liquefaction
+	// 11,000 kg/day = 0.12731 kg/s, drawing 390 kW
+	// scaling to 0.02 g/s, 61.27 W?
+	Process
+	{
+		name = ch4 to lch4 converter
+		modifier = _CH4Converter
+		input = Methane@0.027894
+		input = ElectricCharge@0.06127
+		output = LqdMethane@0.0000469913
+	}
+
+	// RP-1/oxygen burner
+	// burn a small amount of fuel in a stream of oxygen to rapidly heat and compress it
+	// 100 L/s of oxygen gas
+	// since heating up oxygen could be completely passive or completely active based on external temperature, we make 2 assumptions:
+	// 1. the external temperature is high enough that O2 is always above its critical point (90K) (so that vaporization is free)
+	// 2. we have to bring the gaseous O2 from external ambient temp to room temperature
+	// the fuel consumption is therefore defined as the power needed to heat oxygen from external temp to internal temp (20� C)
+	// O2 isochoric specific heat = ~1300 J/(Kg*K) for 0.141 kg/s => 183.3 W/K * 203 K = 37.21 kW
+	// Kerosene HHV = ~46,200 kJ/kg / 37.21 kJ/s = 1241.6 s/kg => 0.0008054 kg/s kerosene
+	// Optimal O/F ratio ~2.6, 0.00209404 kg/s of O2 consumed in combustion
+	// Total O2 flow 0.1431 kg/s, total hydrocarbon flow 0.0008054 kg/s
+	// 0.00289944 kg/s of CO2/H2O generated, but we're just gonna ignore that
+	Process
+	{
+		name = rp1 oxygen vaporizer
+		modifier = _RP1Vaporizer
+		input = LqdOxygen@0.125416
+		input = RP-1@0.000998017
+		output = Oxygen@100
+	}
+	
+	// RG-1/oxygen burner
+	// Same as RP-1 burner, corrected for density
+	Process
+	{
+		name = rg1 oxygen vaporizer
+		modifier = _RG1Vaporizer
+		input = LqdOxygen@0.125416
+		input = RG-1@0.000966867
+		output = Oxygen@100
+	}
+	
+	// Syntin/oxygen burner
+	// Same as RP-1 burner, corrected for density
+	Process
+	{
+		name = syntin oxygen vaporizer
+		modifier = _SyntinVaporizer
+		input = LqdOxygen@0.125416
+		input = Syntin@0.000946416
+		output = Oxygen@100
+	}
+	
+	// Ethanol/oxygen burner
+	// burn a small amount of fuel in a stream of oxygen to rapidly heat and compress it
+	// 100 L/s of oxygen gas
+	// since heating up oxygen could be completely passive or completely active based on external temperature, we make 2 assumptions:
+	// 1. the external temperature is high enough that O2 is always above its critical point (90K) (so that vaporization is free)
+	// 2. we have to bring the gaseous O2 from external ambient temp to room temperature
+	// the fuel consumption is therefore defined as the power needed to heat oxygen from external temp to internal temp (20� C)
+	// O2 isochoric specific heat = ~1300 J/(Kg*K) for 0.141 kg/s => 183.3 W/K * 203 K = 37.21 kW
+	// 75% Ethanol HHV = ~22,275 kJ/kg / 37.21 kJ/s = 598.6 s/kg => 0.001670 kg/s ethanol75
+	// Optimal O/F ratio ~1.42, 0.0023714 kg/s of O2 consumed in combustion
+	// Total O2 flow 0.1434 kg/s, total ethanol flow 0.001670 kg/s
+	// 0.0040414 kg/s of CO2/H2O generated, but we're just gonna ignore that
+	Process
+	{
+		name = ethanol oxygen vaporizer
+		modifier = _EthanolVaporizer
+		input = LqdOxygen@0.125679
+		input = Ethanol75@0.00198396
+		output = Oxygen@100
+	}
+	
+	// Methane/oxygen burner
+	// burn a small amount of fuel in a stream of oxygen/methane to rapidly heat and compress it
+	// 58.74 L/s of oxygen gas, 41.26 L/s of methane gas
+	// since heating up oxygen/methane could be completely passive or completely active based on external temperature, we make 2 assumptions:
+	// 1. the external temperature is high enough that O2/CH4 is always above its critical point (90K/111K) (so that vaporization is free)
+	// 2. we have to bring the gaseous O2/CH4 from external ambient temp to room temperature
+	// the fuel consumption is therefore defined as the power needed to heat oxygen from external temp to internal temp (20� C)
+	// O2 isochoric specific heat = ~1300 J/(Kg*K) for 0.08282 kg/s => 107.7 W/K * 203 K = 21.856 kW
+	// CH4 isochoric specific heat = ~2087 J/(Kg*K) for 0.02958 kg/s => 61.73 W/K * 182 K = 11.235 kW
+	// Methane HHV = ~55,514 kJ/kg / 33.091 kJ/s = 1677.6 s/kg => 0.0005961 kg/s methane
+	// O/F ratio ~2.8, 0.001669 kg/s of O2 consumed in combustion
+	// Total O2 flow 0.08449 kg/s, total methane flow 0.03018 kg/s
+	// 0.002265 kg/s of CO2/H2O generated, but we're just gonna ignore that
+	Process
+	{
+		name = methane oxygen vaporizer
+		modifier = _MethaneVaporizer
+		input = LqdOxygen@0.0740491
+		input = LqdMethane@0.0709100
+		output = Oxygen@58.74
+		output = Methane@41.26
+		dump_valve = Methane,Oxygen
+	}
+
+	// Hydrogen/oxygen burner
+	// burn a small amount of fuel in a stream of oxygen/hydrogen to rapidly heat and compress it
+	// 73.69 L/s of hydrogen gas, 26.31 L/s of oxygen gas
+	// since heating up oxygen/hydrogen could be completely passive or completely active based on external temperature, we make 2 assumptions:
+	// 1. the external temperature is high enough that O2/H2 is always above its critical point (90K/20K) (so that vaporization is free)
+	// 2. we have to bring the gaseous O2/H2 from external ambient temp to room temperature
+	// the fuel consumption is therefore defined as the power needed to heat oxygen from external temp to internal temp (20� C)
+	// O2 isochoric specific heat = ~1300 J/(Kg*K) for 0.0371 kg/s => 48.2 W/K * 203 K = 9.790 kW
+	// H2 isochoric specific heat = ~10 000 J/(Kg*K) for 0.00662 kg/s => 66.25 W/K * 313 K = 20.735 kW
+	// Hydrogen HHV = ~141,584 kJ/kg / 30.525 kJ/s = 4635 s/kg => 0.0002156 kg/s hydrogen
+	// O/F ratio ~8.0, 0.001725 kg/s of O2 consumed in combustion
+	// Total O2 flow 0.03883 kg/s, total H2 flow 0.006836 kg/s
+	// 0.001941 kg/s of H2O generated, but we're just gonna ignore that
+	Process
+	{
+		name = hydrogen oxygen vaporizer
+		modifier = _HydrogenVaporizer
+		input = LqdOxygen@0.0340316
+		input = LqdHydrogen@0.0964855
+		output = Oxygen@26.31
+		output = Hydrogen@73.69
+		dump_valve = Hydrogen,Oxygen
+	}
 
 	Process
 	{
@@ -1354,6 +1494,78 @@ Supply
 		running = true
 	}
 	
+	MODULE
+	{
+		name = ProcessController
+		resource = _LCH4Converter
+		title = LCH4 to GCH4 Converter
+		capacity = 1
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _CH4Converter
+		title = GCH4 to LCH4 Converter
+		capacity = 10
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _RP1Vaporizer
+		title = RP-1 Burning LOX Vaporizer
+		capacity = 1
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _RG1Vaporizer
+		title = RG-1 Burning LOX Vaporizer
+		capacity = 1
+		running = true
+	}
+	
+	MODULE
+	{
+		name = ProcessController
+		resource = _SyntinVaporizer
+		title = Syntin Burning LOX Vaporizer
+		capacity = 1
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _EthanolVaporizer
+		title = Ethanol75 Burning LOX Vaporizer
+		capacity = 1
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _MethaneVaporizer
+		title = CH4 Burning LOX/LCH4 Vaporizer
+		capacity = 1
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _HydrogenVaporizer
+		title = H2 Burning LOX/LH2 Vaporizer
+		capacity = 1
+		running = true
+	}
+
 	processConfigureExclude = true
 	MODULE
 	{
@@ -1437,6 +1649,132 @@ Supply
 			    name = Hydrogen
 			    amount = 0
 			    maxAmount = 4500
+			}
+		}
+		SETUP
+		{
+			name = LCH4 to GCH4 Converter
+			desc = Heats <b>LqdMethane</b> to gaseous <b>Methane</b>.
+			tech = advancedLifeSupport
+			mass = 0.05 //FIXME
+			cost = 20 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _LCH4Converter
+			}
+		}
+		SETUP
+		{
+			name = GCH4 to LCH4 Converter
+			desc = Liquifies gaseous <b>Methane</b> into <b>LqdMethane</b>.
+			tech = advancedLifeSupport
+			mass = 0.1 //FIXME
+			cost = 100 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _CH4Converter
+			}
+			RESOURCE
+			{
+			    name = Methane
+			    amount = 0
+			    maxAmount = 1000
+			}
+		}
+		SETUP
+		{
+			name = RP-1 Burning LOX Vaporizer
+			desc = Heats <b>LqdOxygen</b> to <b>Oxygen</b> by burning a small amount of <b>RP-1</b>.
+			tech = advancedLifeSupport
+			mass = 0.05 //FIXME
+			cost = 100 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _RP1Vaporizer
+			}
+		}
+		SETUP
+		{
+			name = RG-1 Burning LOX Vaporizer
+			desc = Heats <b>LqdOxygen</b> to <b>Oxygen</b> by burning a small amount of <b>RG-1</b>.
+			tech = advancedLifeSupport
+			mass = 0.05 //FIXME
+			cost = 100 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _RG1Vaporizer
+			}
+		}
+		SETUP
+		{
+			name = Syntin Burning LOX Vaporizer
+			desc = Heats <b>LqdOxygen</b> to <b>Oxygen</b> by burning a small amount of <b>Syntin</b>.
+			tech = advancedLifeSupport
+			mass = 0.05 //FIXME
+			cost = 100 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _SyntinVaporizer
+			}
+		}
+		SETUP
+		{
+			name = Ethanol75 Burning LOX Vaporizer
+			desc = Heats <b>LqdOxygen</b> to <b>Oxygen</b> by burning a small amount of <b>Ethanol75</b>.
+			tech = advancedLifeSupport
+			mass = 0.05 //FIXME
+			cost = 100 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _EthanolVaporizer
+			}
+		}
+		SETUP
+		{
+			name = CH4 Burning LOX/LCH4 Vaporizer
+			desc = Heats <b>LqdOxygen</b> and <b>LqdMethane</b> to <b>Oxygen</b> and <b>Methane</b> by burning a small amount of <b>LqdMethane</b>.
+			tech = advancedLifeSupport
+			mass = 0.05 //FIXME
+			cost = 100 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _MethaneVaporizer
+			}
+		}
+		SETUP
+		{
+			name = H2 Burning LOX/LH2 Vaporizer
+			desc = Heats <b>LqdOxygen</b> and <b>LqdHydrogen</b> to <b>Oxygen</b> and <b>Hydrogen</b> by burning a small amount of <b>LqdHydrogen</b>.
+			tech = advancedLifeSupport
+			mass = 0.05 //FIXME
+			cost = 100 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _HydrogenVaporizer
 			}
 		}
 	}
@@ -1829,6 +2167,94 @@ RESOURCE_DEFINITION
 @PART:HAS[@MODULE[ProcessController]:HAS[#resource[_H2Converter]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
 {
 	@tags ^=:$:, lh2, lqdhydrogen, hydrogen liquifier, liquefier, liquefaction, liquid hydrogen, hydrogen converter, converter
+}
+
+RESOURCE_DEFINITION
+{
+  name = _LCH4Converter
+  density = 0.0
+  isVisible = false
+}
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_LCH4Converter]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
+{
+	@tags ^=:$:, ch4, methane, lqdmethane evaporator, evaporator, gas, methane converter, converter
+}
+
+RESOURCE_DEFINITION
+{
+  name = _CH4Converter
+  density = 0.0
+  isVisible = false
+}
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_CH4Converter]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
+{
+	@tags ^=:$:, lch4, lqdmethane, methane liquifier, liquefier, liquefaction, liquid methane, methane converter, converter
+}
+
+RESOURCE_DEFINITION
+{
+  name = _RP1Vaporizer
+  density = 0.0
+  isVisible = false
+}
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_RP1Vaporizer]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
+{
+	@tags ^=:$:, rp1, kerosene, lqdoxygen, oxygen vaporizer, burner, vaporizer, oxygen gas, oxygen converter, converter
+}
+
+RESOURCE_DEFINITION
+{
+  name = _RG1Vaporizer
+  density = 0.0
+  isVisible = false
+}
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_RG1Vaporizer]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
+{
+	@tags ^=:$:, rg1, kerosene, lqdoxygen, oxygen vaporizer, burner, vaporizer, oxygen gas, oxygen converter, converter
+}
+
+RESOURCE_DEFINITION
+{
+  name = _SyntinVaporizer
+  density = 0.0
+  isVisible = false
+}
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_SyntinVaporizer]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
+{
+	@tags ^=:$:, syntin, kerosene, lqdoxygen, oxygen vaporizer, burner, vaporizer, oxygen gas, oxygen converter, converter
+}
+
+RESOURCE_DEFINITION
+{
+  name = _EthanolVaporizer
+  density = 0.0
+  isVisible = false
+}
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_EthanolVaporizer]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
+{
+	@tags ^=:$:, ethanol, lqdoxygen, oxygen vaporizer, burner, vaporizer, oxygen gas, oxygen converter, converter
+}
+
+RESOURCE_DEFINITION
+{
+  name = _MethaneVaporizer
+  density = 0.0
+  isVisible = false
+}
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_MethaneVaporizer]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
+{
+	@tags ^=:$:, methane, oxygen, lqdoxygen, lqdmethane, methane oxygen vaporizer, burner, vaporizer, oxygen gas, methane gas, methane oxygen converter, converter
+}
+
+RESOURCE_DEFINITION
+{
+  name = _HydrogenVaporizer
+  density = 0.0
+  isVisible = false
+}
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_HydrogenVaporizer]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
+{
+	@tags ^=:$:, hydrogen, oxygen, lqdoxygen, lqdhydrogen, hydrogen oxygen vaporizer, burner, vaporizer, oxygen gas, hydrogen gas, hydrogen oxygen converter, converter
 }
 
 RESOURCE_DEFINITION


### PR DESCRIPTION
Add gas generator options to liquefier. These burn a small amount of fuel to rapidly vaporize large amounts of propellant (oxygen, methane, hydrogen). This allows cryogenic scavenging RCS configs to be reliably fed from liquid resources.