### PR TITLE
Correct LM ascent stage dry mass

### DIFF
--- a/GameData/KerbalismConfig/Support/ROCapsules.cfg
+++ b/GameData/KerbalismConfig/Support/ROCapsules.cfg
@@ -443,12 +443,12 @@
 {
 	@description ^= :$: Supports a crew of two for up to 3 days of active operations.
 
-	@mass -= 0.8502		//-72.27 kg (LS Resources) - 12.75 kg (LS Tanks)
+	@mass -= 0.08502		//-72.27 kg (LS Resources) - 12.75 kg (LS Tanks)
 
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume += 132.85
-		@basemass -= 0.8502
+		@basemass -= 0.08502
 
 		TANK
 		{


### PR DESCRIPTION
add a misplaced zero to subtract the correct amount of mass from the LM ascent stage.

Needs https://github.com/KSP-RO/ROCapsules/pull/158