### PR TITLE
Support for AES LM parts, and gaseous reactant fuel cells

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -1277,7 +1277,7 @@ Supply
 		{
 			name = Gaseous Reactant Fuel Cell
 			desc = Combines <b>Hydrogen</b> and <b>Oxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-			tech = lunarRatedPower
+			tech = spaceStationSolarPanels
 			mass = 0.100	//heavier due to higher heat rejection requirements
 
 			MODULE

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -400,6 +400,28 @@ Supply
 		dump = Water
 	}
 	
+	//AES LEM Shelter Allis-Chalmers high temp fuel cell
+	// Source: Apollo Extension Systems - Lunar Excursion Module Phase B vol. 5
+	// Uses gaseuos reactants to allow for indefinite storage on lunar surface
+	// 65.5% efficiency (HHV? 77.6% by LHV)
+	// Hydrogen has a LHV of 120 MJ/kg (LHV is probably appropriate for high temperature fuel cells)
+	// Gaseous Hydrogen has a density of 0.00008990 kg/L
+	// Therefore, we need 0.0926956 / 0.776 = 0.119453 L/s of Lqd Hydrogen to generate 1 kW
+	// Gaseous Oxygen has a density of 0.00141 kg/L
+	// running stoich, we then need 0.0604438 L/s of Lqd Oxygen to match
+	// 0.0000107388 kg/s H2, 0.0000852258 kg/s O2
+	// this will produce 0.0000959646 kg/s = 0.0000959646 L/s water
+	Process
+	{
+		name = gaseous reactant fuel cell
+		modifier = _FuelCellGas
+		input = Oxygen@0.0604438
+		input = Hydrogen@0.119453
+		output = Water@0.0000959646
+		output = ElectricCharge@1.0
+		dump = Water
+	}
+	
 	//Soyuz-LOK Volna-20 Fuel cell
 	// source: http://www.astronautix.com/l/lokpao.html
 	// no good info, but 600 kg reactants for 500 hours suggests not very efficient
@@ -1193,6 +1215,14 @@ Supply
 	MODULE
 	{
 		name = ProcessController
+		resource = _FuelCellGas
+		title = Gaseous Reactant Fuel Cell
+		capacity = 1
+		running = true
+	}
+	MODULE
+	{
+		name = ProcessController
 		resource = _FuelCellVolna20
 		title = Soyuz Fuel Cell
 		capacity = 1
@@ -1230,7 +1260,7 @@ Supply
 
 		SETUP //Apollo
 		{
-			name = Apollo alkaline Fuel Cell
+			name = Apollo Alkaline Fuel Cell
 			desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
 			tech = lunarRatedPower
 			mass = 0.075
@@ -1240,6 +1270,21 @@ Supply
 				type = ProcessController
 				id_field = resource
 				id_value = _FuelCell
+			}
+		}
+
+		SETUP //AES A-C Fuel Cell
+		{
+			name = Gaseous Reactant Fuel Cell
+			desc = Combines <b>Hydrogen</b> and <b>Oxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
+			tech = lunarRatedPower
+			mass = 0.100	//heavier due to higher heat rejection requirements
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _FuelCellGas
 			}
 		}
 
@@ -2111,6 +2156,12 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = _FuelCellVolna20
+  density = 0.0
+  isVisible = false
+}
+RESOURCE_DEFINITION
+{
+  name = _FuelCellGas
   density = 0.0
   isVisible = false
 }

--- a/GameData/KerbalismConfig/Support/ROCapsules.cfg
+++ b/GameData/KerbalismConfig/Support/ROCapsules.cfg
@@ -443,12 +443,12 @@
 {
 	@description ^= :$: Supports a crew of two for up to 3 days of active operations.
 
-	@mass -= 0.8502		//-72.27 kg (LS Resources) - 12.75 kg (LS Tanks)
+	@mass -= 0.08502		//-72.27 kg (LS Resources) - 12.75 kg (LS Tanks)
 
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume += 132.85
-		@basemass -= 0.8502
+		@basemass -= 0.08502
 
 		TANK
 		{
@@ -490,6 +490,104 @@
 			name = WasteWater
 			amount = 0
 			maxAmount = 29.3
+		}
+	}
+}
+@PART[ROC-LEMAscentTaxiBDB]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+{
+	@description ^= :$: Supports a crew of three for up to 46 hours of active operations.
+
+	@mass -= 0.05213		// - 10.06 kg (LS tank) - 42.07 kg (LS resources)
+
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume += 98.0
+		@basemass -= 0.05213
+
+		TANK
+		{
+			name = Food
+			amount = 33.62
+			maxAmount = 33.62
+		}
+
+		TANK
+		{
+			name = Water
+			amount = 22.19
+			maxAmount = 22.19
+		}
+
+		TANK
+		{
+			name = Oxygen
+			amount = 2316
+			maxAmount = 2316
+		}
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 4.91
+			maxAmount = 4.91
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 3.2
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 29.3
+		}
+	}
+}
+@PART[ROC-LEMShelterBDB]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+{
+	@description ^= :$: Supports a crew of two for up to 14 days of active operations.
+
+	@mass -= 0.1242		// - 41.0 kg (LS tank) - 83.20 kg (LS resources)
+
+	@MODULE[ModuleFuelTanks]
+	{
+		@volume += 426.47
+		@basemass -= 0.1242
+
+		TANK
+		{
+			name = Food
+			amount = 179.6
+			maxAmount = 179.6
+		}
+
+		//Relies on descent stage water tank
+
+		//Relies on descent stage oxygen tank
+
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 22.37		//25.2 - 2.83 in descent stage
+			maxAmount = 22.37
+		}
+
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 179.6
+		}
+
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 44.9
 		}
 	}
 }
@@ -731,11 +829,20 @@
 		%max_pressure = 0.55	//pressurized to 0.5 atm
 	}
 }
-@PART[ROC-LEMAscent|ROC-LEMAscentBDB]:NEEDS[ROCapsules,FeatureHabitat]:AFTER[zzzKerbalism]
+@PART[ROC-LEMAscent|ROC-LEMAscentBDB|ROC-LEMAscentTaxiBDB]:NEEDS[ROCapsules,FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat]
 	{
 		%volume = 4.5
+		%surface = 18.1		 //guesstimate
+		%max_pressure = 0.35
+	}
+}
+@PART[ROC-LEMShelterBDB]:NEEDS[ROCapsules,FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%volume = 5.0	//A little more volume from removing equipment/engine and adding airlock
 		%surface = 18.1		 //guesstimate
 		%max_pressure = 0.35
 	}

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -859,7 +859,7 @@
     {
       name = Fuel Cells
       desc = 4.00 kW fuel cell unit that consumes <b>Hydrogen</b> and <b>Oxygen</b> to generate <b>Water</b>.
-      tech = lunarRatedPower
+      tech = spaceStationSolarPanels
             
       MODULE
       {

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -788,7 +788,7 @@
   }
 }
 //Landers
-@PART[ROC-LEMAscent|ROC-LEMAscentBDB|LEM_ASCENT_STAGE|FASALM_AscentStage|bluedog_LEM_Ascent_Cockpit|landerCabinMedium|mk2LanderCan|mk2LanderCabin_v2|SXTLander|SSTU-LC2-POD|rn_lk_lander]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[ROC-LEMAscent|ROC-LEMAscentBDB|ROC-LEMAscentTaxiBDB|LEM_ASCENT_STAGE|FASALM_AscentStage|bluedog_LEM_Ascent_Cockpit|landerCabinMedium|mk2LanderCan|mk2LanderCabin_v2|SXTLander|SSTU-LC2-POD|rn_lk_lander]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
   %capsuleScrubbers = true
   %scrubberCapacity = 1.67
@@ -799,6 +799,74 @@
     @RESOURCE[ElectricCharge]
     {
       @rate -= 0.202  //Remove Climatization and LS power draw
+    }
+  }
+}
+//LM Shelter
+@PART[ROC-LEMShelterBDB]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+  %capsuleScrubbers = true
+  %scrubberCapacity = 1.67
+  %capsuleOrigin = US
+
+  @MODULE[ModuleCommand]
+  {
+    @RESOURCE[ElectricCharge]
+    {
+      @rate -= 0.202  //Remove Climatization and LS power draw
+    }
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _FuelCellGas
+    title = Fuel Cells 
+    capacity = 4.00	//2x 2 kW A-C fuel cells
+    running = true
+  }
+  MODULE
+  {
+    name = ProcessController
+    resource = _PressureControlOxygen
+    title = O2 Pressure Controller
+    capacity = 5
+    running = true
+  }
+
+  processConfigureExclude = true
+  MODULE
+  {
+    name = Configure
+    title = Processes
+    slots = 2
+
+    SETUP
+    {
+      name = O2 Pressure Controller
+      desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
+      tech = crewSurvivability
+            
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _PressureControlOxygen
+      }
+    }
+
+    SETUP
+    {
+      name = Fuel Cells
+      desc = 4.00 kW fuel cell unit that consumes <b>Hydrogen</b> and <b>Oxygen</b> to generate <b>Water</b>.
+      tech = lunarRatedPower
+            
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _FuelCellGas
+      }
     }
   }
 }


### PR DESCRIPTION
Add support for ROCapsules AES LM Phase B parts. Also add a gaseous reactant fuel cell config, based on the AES LM Allis-Chalmers fuel cell.

For https://github.com/KSP-RO/ROCapsules/pull/160/