### PR TITLE
Create RN_Salyut.cfg, add basic habitat and comfort info

### DIFF
--- a/GameData/KerbalismConfig/Support/RN_Salyut.cfg
+++ b/GameData/KerbalismConfig/Support/RN_Salyut.cfg
@@ -1,0 +1,28 @@
+@PART[salyut1-4|salyut6|salyut7|almaz3-5]:NEEDS[RN_Salyut]:AFTER[RN_Salyut]
+{
+	@MODULE[Habitat]
+	{	
+		%volume = 90 //https://www.hq.nasa.gov/pao/History/SP-4225/documentation/mhh/mirheritage.pdf Almaz 3 was actually slightly larger at 100 m3
+		%surface = 149.6 //estimate based off the multiple cylinders of a Salyut/Almaz. 2*pi*1*3 + 2*pi*1.45*3.8 + 2*pi*2.075*5.3 + 2*pi*2.075^2
+	}
+	
+	//Salyut and Almaz stations had treadmills https://www.russianspaceweb.com/salyut1-design.html (and previous source)
+	MODULE:NEEDS[FeatureComfort]
+	{
+		name = Comfort
+		bonus = exercise
+		desc = A treadmill designed to permit exercise in zero-g is included. The crew will love it.
+	}
+
+	MODULE:NEEDS[FeatureReliability]
+	{
+		name = Reliability
+		type = Comfort
+		title = Treadmill
+		repair = Engineer
+		mtbf = 36288000
+		extra_cost = 0.25
+		extra_mass = 0.05
+	}
+	@tags ^= :$: comfort:
+}


### PR DESCRIPTION
The RN Salyut mod currently has no Kerbalism config, but is configured for RP-1.
This PR adds a config file for the RN Salyut mod, adding basic habitat volume and surface information for the Salyut and Almaz stations. This config file also adds their treadmills.