### PR TITLE
Fix the volumes and surface areas of several habitats

### DIFF
--- a/GameData/KerbalismConfig/System/Habitat.cfg
+++ b/GameData/KerbalismConfig/System/Habitat.cfg
@@ -219,9 +219,10 @@
 }
 @PART[mk3Cockpit_Shuttle|benjee10_shuttle_forwardFuselage]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
-	@MODULE[Habitat]
+	@MODULE[Habitat] // 5.2m tall (actual living space), 5.6m diameter
 	{
-		%volume = 132.0
+		%volume = 54.27 // dimensions gives 128.08m^3, ill divide by 2.36 to keep it consistent with landerCabinSmall
+  		%surface = 94.46 // dimensions gives 140.74m^2, ill divide by 1.49 to keep it consistent with landerCabinSmall
 	}
 }
 @PART[XOrionPodXbb31|SSTU-SC-C-CM]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
@@ -260,56 +261,56 @@
 {
 	@MODULE[Habitat] // no idea what these numbers are based off of from kerbalism, so ill just keep em as is
 	{
-		volume = 4.09
-		surface = 9.54
+		%volume = 4.09
+		%surface = 9.54
 	}
 }
 @PART[mk2LanderCabin,mk2LanderCabin_v2]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat] // 1.9m tall, 4.1m diameter
 	{
-		volume = 10.63 // dimensions gives 25.08m^3, ill divide by 2.36 to keep it consistent with landerCabinSmall
-		surface = 34.15 // dimensions gives 50.88m^2, ill divide by 1.49 to keep it consistent with landerCabinSmall
+		%volume = 10.63 // dimensions gives 25.08m^3, ill divide by 2.36 to keep it consistent with landerCabinSmall
+		%surface = 34.15 // dimensions gives 50.88m^2, ill divide by 1.49 to keep it consistent with landerCabinSmall
 	}
 }
 @PART[crewCabin]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat] // 3.3m tall, 4.2m diameter
 	{
-		volume = 19.37 // dimensions give 45.72m^3, dividing by 2.36
-		surface = 47.82 // dimensions give 71.25m^2, dividing by 1.49
+		%volume = 19.37 // dimensions give 45.72m^3, dividing by 2.36
+		%surface = 47.82 // dimensions give 71.25m^2, dividing by 1.49
 	}
 }
 @PART[cupola]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat] // cylinder: 1.2m tall, 4.4m diameter, cone: .7m tall, 2.1m top diameter, 2.8m bottom diameter
 	{
-		volume = 9.14 // dimensions give 21.57m^3, dividing by 2.36
-		surface = 42.04 // dimensions give 62.64m^2, dividing by 1.49
+		%volume = 9.14 // dimensions give 21.57m^3, dividing by 2.36
+		%surface = 42.04 // dimensions give 62.64m^2, dividing by 1.49
 	}
 }
 @PART[mk2Cockpit_Standard]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat] // 3.1m tall, 2.0m diameter
 	{
-		volume = 4.13 // dimensions give 9.74, dividing by 2.36
-		surface = 17.29 // dimensions give 25.76, dividing by 1.49
+		%volume = 4.13 // dimensions give 9.74, dividing by 2.36
+		%surface = 17.29 // dimensions give 25.76, dividing by 1.49
 	}
 }
 @PART[mk2Cockpit_Inline]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat] // 4.5m tall, 2.0m diameter
 	{
-		volume = 6.0 // dimensions give 14.14, dividing by 2.36
-		surface = 23.19 // dimensions give 34.56, dividing by 1.49
+		%volume = 6.0 // dimensions give 14.14, dividing by 2.36
+		%surface = 23.19 // dimensions give 34.56, dividing by 1.49
 	}
 }
 @PART[mk3CrewCabin]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	@MODULE[Habitat] // 6.7m tall, 5.6m diameter
 	{
-		volume = 69.92 // dimensions give 165.02, dividing by 2.36
-		surface = 112.17 // dimensions give 167.13, dividing by 1.49
+		%volume = 69.92 // dimensions give 165.02, dividing by 2.36
+		%surface = 112.17 // dimensions give 167.13, dividing by 1.49
 	}
 }
 // ============================================================================

--- a/GameData/KerbalismConfig/System/Habitat.cfg
+++ b/GameData/KerbalismConfig/System/Habitat.cfg
@@ -256,6 +256,70 @@
 		%surface = 70	//guesstimate
 	}
 }
+@PART[landerCabinSmall]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 2.10
+		surface = 8.8
+	}
+}
+@PART[Mark1-2Pod]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 4.09
+		surface = 9.54
+	}
+}
+@PART[mk2LanderCabin,mk2LanderCabin_v2]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 3.9
+		surface = 14.5
+	}
+}
+@PART[crewCabin]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 9.2
+		surface = 16.0
+	}
+}
+@PART[cupola]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 4.1
+		surface = 10.5
+	}
+}
+@PART[mk2Cockpit_Standard]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 3.5
+		surface = 19.5
+	}
+}
+@PART[mk2Cockpit_Inline]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 6.5
+		surface = 18.0
+	}
+}
+@PART[mk3CrewCabin]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 38.0
+		surface = 44.0
+	}
+}
 // ============================================================================
 // Unpressurized tag
 // ============================================================================

--- a/GameData/KerbalismConfig/System/Habitat.cfg
+++ b/GameData/KerbalismConfig/System/Habitat.cfg
@@ -257,7 +257,7 @@
 		%surface = 70	//guesstimate
 	}
 }
-@PART[Mark1-2Pod]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[Mark1-2Pod]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat] // no idea what these numbers are based off of from kerbalism, so ill just keep em as is
 	{
@@ -265,7 +265,7 @@
 		%surface = 9.54
 	}
 }
-@PART[mk2LanderCabin,mk2LanderCabin_v2]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[mk2LanderCabin|mk2LanderCabin_v2]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat] // 1.9m tall, 4.1m diameter
 	{
@@ -273,7 +273,7 @@
 		%surface = 34.15 // dimensions gives 50.88m^2, ill divide by 1.49 to keep it consistent with landerCabinSmall
 	}
 }
-@PART[crewCabin]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[crewCabin]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat] // 3.3m tall, 4.2m diameter
 	{
@@ -281,7 +281,7 @@
 		%surface = 47.82 // dimensions give 71.25m^2, dividing by 1.49
 	}
 }
-@PART[cupola]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[cupola]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat] // cylinder: 1.2m tall, 4.4m diameter, cone: .7m tall, 2.1m top diameter, 2.8m bottom diameter
 	{
@@ -289,7 +289,7 @@
 		%surface = 42.04 // dimensions give 62.64m^2, dividing by 1.49
 	}
 }
-@PART[mk2Cockpit_Standard]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[mk2Cockpit_Standard]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat] // 3.1m tall, 2.0m diameter
 	{
@@ -297,7 +297,7 @@
 		%surface = 17.29 // dimensions give 25.76, dividing by 1.49
 	}
 }
-@PART[mk2Cockpit_Inline]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[mk2Cockpit_Inline]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat] // 4.5m tall, 2.0m diameter
 	{
@@ -305,7 +305,7 @@
 		%surface = 23.19 // dimensions give 34.56, dividing by 1.49
 	}
 }
-@PART[mk3CrewCabin]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[mk3CrewCabin]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat] // 6.7m tall, 5.6m diameter
 	{

--- a/GameData/KerbalismConfig/System/Habitat.cfg
+++ b/GameData/KerbalismConfig/System/Habitat.cfg
@@ -172,9 +172,9 @@
 		%max_pressure = 0.35
 	}
 }
-@PART[LEM_ASCENT_STAGE|FASALM_AscentStage|MEMLanderSXT|MEMLander|landerCabinMedium]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+@PART[LEM_ASCENT_STAGE|FASALM_AscentStage|MEMLanderSXT|MEMLander|landerCabinMedium|landerCabinSmall]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
-	@MODULE[Habitat]
+	@MODULE[Habitat] // 2.0m tall, 2.6m diameter
 	{
 		%volume = 4.5
 		%surface = 18.1      //guesstimate
@@ -256,17 +256,9 @@
 		%surface = 70	//guesstimate
 	}
 }
-@PART[landerCabinSmall]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
-{
-	@MODULE[Habitat]
-	{
-		volume = 2.10
-		surface = 8.8
-	}
-}
 @PART[Mark1-2Pod]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
-	@MODULE[Habitat]
+	@MODULE[Habitat] // no idea what these numbers are based off of from kerbalism, so ill just keep em as is
 	{
 		volume = 4.09
 		surface = 9.54
@@ -274,50 +266,50 @@
 }
 @PART[mk2LanderCabin,mk2LanderCabin_v2]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
-	@MODULE[Habitat]
+	@MODULE[Habitat] // 1.9m tall, 4.1m diameter
 	{
-		volume = 3.9
-		surface = 14.5
+		volume = 10.63 // dimensions gives 25.08m^3, ill divide by 2.36 to keep it consistent with landerCabinSmall
+		surface = 34.15 // dimensions gives 50.88m^2, ill divide by 1.49 to keep it consistent with landerCabinSmall
 	}
 }
 @PART[crewCabin]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
-	@MODULE[Habitat]
+	@MODULE[Habitat] // 3.3m tall, 4.2m diameter
 	{
-		volume = 9.2
-		surface = 16.0
+		volume = 19.37 // dimensions give 45.72m^3, dividing by 2.36
+		surface = 47.82 // dimensions give 71.25m^2, dividing by 1.49
 	}
 }
 @PART[cupola]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
-	@MODULE[Habitat]
+	@MODULE[Habitat] // cylinder: 1.2m tall, 4.4m diameter, cone: .7m tall, 2.1m top diameter, 2.8m bottom diameter
 	{
-		volume = 4.1
-		surface = 10.5
+		volume = 9.14 // dimensions give 21.57m^3, dividing by 2.36
+		surface = 42.04 // dimensions give 62.64m^2, dividing by 1.49
 	}
 }
 @PART[mk2Cockpit_Standard]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
-	@MODULE[Habitat]
+	@MODULE[Habitat] // 3.1m tall, 2.0m diameter
 	{
-		volume = 3.5
-		surface = 19.5
+		volume = 4.13 // dimensions give 9.74, dividing by 2.36
+		surface = 17.29 // dimensions give 25.76, dividing by 1.49
 	}
 }
 @PART[mk2Cockpit_Inline]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
-	@MODULE[Habitat]
+	@MODULE[Habitat] // 4.5m tall, 2.0m diameter
 	{
-		volume = 6.5
-		surface = 18.0
+		volume = 6.0 // dimensions give 14.14, dividing by 2.36
+		surface = 23.19 // dimensions give 34.56, dividing by 1.49
 	}
 }
 @PART[mk3CrewCabin]:NEEDS[FeatureHabitat]:AFTER[KerbalismDefault]
 {
-	@MODULE[Habitat]
+	@MODULE[Habitat] // 6.7m tall, 5.6m diameter
 	{
-		volume = 38.0
-		surface = 44.0
+		volume = 69.92 // dimensions give 165.02, dividing by 2.36
+		surface = 112.17 // dimensions give 167.13, dividing by 1.49
 	}
 }
 // ============================================================================

--- a/GameData/KerbalismConfig/System/Sickbay.cfg
+++ b/GameData/KerbalismConfig/System/Sickbay.cfg
@@ -9,7 +9,7 @@ PARTUPGRADE:NEEDS[RP-0,FeatureComfort]
   techRequired = improvedHabitats
   title = Permanent habitation
   manufacturer = Mesmer and Ize
-  description = Thanks to advancements in virtual reality, digital entertainment and human health and psicology studies, permanent habitation is now possible. Some form of gravity is still required, so being landed or using a centrifuge is a necessity.
+  description = Thanks to advancements in virtual reality, digital entertainment and human health and psychology studies, permanent habitation is now possible. Some form of gravity is still required, so being landed or using a centrifuge is a necessity.
 }
 
 @PART[*]:HAS[@MODULE[GravityRing]]:NEEDS[ProfileRealismOverhaul,FeatureComfort]:AFTER[zzzKerbalism]


### PR DESCRIPTION
For some reason, when a part has its habitat defined in https://github.com/KSP-RO/Kerbalism/blob/7e279c3bccae30eff1ab6612b2b69e78214f4983/GameData/KerbalismConfig/System/Habitat.cfg but NOT in https://github.com/KSP-RO/ROKerbalism/blob/0ae007bf2789abf136ff05367a42e366ecd6dd62/GameData/KerbalismConfig/System/Habitat.cfg, there is a strange bug that massively multiplies that parts volume and surface area by a seemingly random amount.

For example, according to https://github.com/KSP-RO/Kerbalism/blob/7e279c3bccae30eff1ab6612b2b69e78214f4983/GameData/KerbalismConfig/System/Habitat.cfg#L59, landerCabinSmall is supposed to have a volume of 2.1m^3, when it actually has 10.37m^3 ingame.

![image](https://github.com/user-attachments/assets/0c5fc84d-0a35-4f78-b406-77d0003b37cd)

Another example, according to https://github.com/KSP-RO/Kerbalism/blob/7e279c3bccae30eff1ab6612b2b69e78214f4983/GameData/KerbalismConfig/System/Habitat.cfg#L91. cupola is supposed to have a volume of 4.1m^3, when it actually has 18.77m^3 ingame.
![image](https://github.com/user-attachments/assets/ca4125ad-189d-40cd-8c82-e5edcd69c5d6)

I have 0 idea where these values are coming from, as searching them up in the KSP-RO org gives no results, so I think its either a KSP bug or a kerbalism bug.
There was a substantial difference between the volumes and surfaces areas in Kerbalism vs ROKerbalism, so I had to manually calculate the volume/sa of the cylinders of each of these parts, and then scale them according to how landerCabinSmall scaled. It's a bit arbitrary, but it does give decent results.
This pull adds habitats for the following parts, all of which were defined in Kerbalism but not in ROKerbalism, giving them wacky values:
landerCabinSmall (just sets it to the same as landerCabinMedium, because they have the exact same shape and having them different is confusing for the player)
mk2LanderCabin_v2
crewCabin
cupola
mk2Cockpit_Standard
mk2Cockpit_Inline
mk3CrewCabin
Mark1-2Pod
mk2LanderCabin

Additionally, it also changes the habitat for mk3Cockpit_Shuttle to be a bit more reasonable when combined with the new mk3CrewCabin.