### PR TITLE
Add NFE Snap reactor Pseudo-resources

### DIFF
--- a/GameData/KerbalismConfig/Support/NearFuture.cfg
+++ b/GameData/KerbalismConfig/Support/NearFuture.cfg
@@ -692,6 +692,27 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
 
 RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
 {
+	name = _SNAP5035reactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _SNAP2reactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
+	name = _SNAP8reactor
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
+{
 	name = _TOPAZIIreactor
 	density = 0.0
 	isVisible = false


### PR DESCRIPTION
Snap-50 35kw, Snap-2 & Snap-8 NFE reactors show no electrical output in VAB until these pseudo-resources are added