### PR TITLE
Rename life support nodes to be less confusing for users and developers

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -1072,7 +1072,7 @@ Supply
 		{
 			name = LiOHScrubber
 			desc = A Lithium Hydroxide scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.02 //FIXME
 			cost = 25 //FIXME
 
@@ -1088,7 +1088,7 @@ Supply
 		{
 			name = KO2 Scrubber
 			desc = A Potassium superoxide scrubber that absorbs <b>CarbonDioxide</b> from the internal atmosphere and generates <b>Oxygen</b> for the crew.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.05 //FIXME
 			cost = 40 //FIXME
 
@@ -1136,7 +1136,7 @@ Supply
 		{
 			name = N2 Pressure Control
 			desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.05 //FIXME
 			cost = 25 //FIXME
 
@@ -1152,7 +1152,7 @@ Supply
 		{
 			name = O2 Pressure Control
 			desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.01 //FIXME
 			cost = 25 //FIXME
 
@@ -1200,7 +1200,7 @@ Supply
 		{
 			name = LOX to GOX Converter
 			desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.005 //FIXME
 			cost = 20 //FIXME
 
@@ -1826,7 +1826,7 @@ Supply
 		{
 			name = LOX to GOX Converter
 			desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.05 //FIXME
 			cost = 50 //FIXME
 

--- a/GameData/KerbalismConfig/Support/AlternateApollo.cfg
+++ b/GameData/KerbalismConfig/Support/AlternateApollo.cfg
@@ -188,7 +188,7 @@
         {
             name = LOX to GOX Converter
             desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-            tech = lifeSupportISRU
+            tech = earlyLifeSupport
 	        mass = 0.0
             cost = 0
 

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -310,7 +310,7 @@
 		{
 			name = N2 Pressure Control
 			desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.05 //FIXME
 			cost = 25 //FIXME
 			MODULE
@@ -325,7 +325,7 @@
 		{
 			name = O2 Pressure Control
 			desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.01 //FIXME
 			cost = 25 //FIXME
 			MODULE

--- a/GameData/KerbalismConfig/Support/ROStations.cfg
+++ b/GameData/KerbalismConfig/Support/ROStations.cfg
@@ -90,7 +90,7 @@
 		{
 			name = LiOHScrubber
 			desc = A Lithium Hydroxide scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.02 //FIXME
 			cost = 25 //FIXME
 
@@ -106,7 +106,7 @@
 		{
 			name = KO2 Scrubber
 			desc = A Potassium superoxide scrubber that absorbs <b>CarbonDioxide</b> from the internal atmosphere and generates <b>Oxygen</b> for the crew.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.05 //FIXME
 			cost = 40 //FIXME
 
@@ -154,7 +154,7 @@
 		{
 			name = N2 Pressure Control
 			desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.05 //FIXME
 			cost = 25 //FIXME
 
@@ -170,7 +170,7 @@
 		{
 			name = O2 Pressure Control
 			desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.01 //FIXME
 			cost = 25 //FIXME
 
@@ -218,7 +218,7 @@
 		{
 			name = LOX to GOX Converter
 			desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.005 //FIXME
 			cost = 20 //FIXME
 

--- a/GameData/KerbalismConfig/Support/US2.cfg
+++ b/GameData/KerbalismConfig/Support/US2.cfg
@@ -249,7 +249,7 @@
 	
 	@title = Universal Storage: Life Support Module
 	
-	%TechRequired = earlyLifeSupport
+	%TechRequired = rudimentaryLifeSupport
 	
 	!MODULE[TacGenericConverter] {}
 	!MODULE[ModuleResourceConverter] {}
@@ -351,7 +351,7 @@
 		{
 			name = LiOHScrubber
 			desc = A Lithium Hydroxide scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.02 //FIXME
 			cost = 25 //FIXME
 			MODULE
@@ -366,7 +366,7 @@
 		{
 			name = KO2 Scrubber
 			desc = A Potassium superoxide scrubber that absorbs <b>CarbonDioxide</b> from the internal atmosphere and generates <b>Oxygen</b> for the crew.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.05 //FIXME
 			cost = 40 //FIXME
 			MODULE
@@ -409,7 +409,7 @@
 		{
 			name = N2 Pressure Control
 			desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.05 //FIXME
 			cost = 25 //FIXME
 			MODULE
@@ -423,7 +423,7 @@
 		{
 			name = O2 Pressure Control
 			desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
-			tech = earlyLifeSupport
+			tech = rudimentaryLifeSupport
 			mass = 0.01 //FIXME
 			cost = 25 //FIXME
 			MODULE
@@ -615,7 +615,7 @@
 		{
 			name = LOX to GOX Converter
 			desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-			tech = lifeSupportISRU
+			tech = earlyLifeSupport
 			mass = 0.01
 			cost = 20
 			MODULE
@@ -629,7 +629,7 @@
 		{
 			name = GOX to LOX Converter
 			desc = Liquifies breathable <b>Oxygen</b> into <b>LqdOxygen</b>.
-			tech = lifeSupportISRU
+			tech = earlyLifeSupport
 			mass = 0.034
 			cost = 20
 			MODULE
@@ -790,7 +790,7 @@
 		{
 			name = LOX to GOX Converter
 			desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-			tech = lifeSupportISRU
+			tech = earlyLifeSupport
 			mass = 0.01
 			cost = 20
 			MODULE
@@ -804,7 +804,7 @@
 		{
 			name = GOX to LOX Converter
 			desc = Liquifies breathable <b>Oxygen</b> into <b>LqdOxygen</b>.
-			tech = lifeSupportISRU
+			tech = earlyLifeSupport
 			mass = 0.1
 			cost = 20
 			MODULE

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -340,7 +340,7 @@
     {
       name = LOX to GOX Converter
       desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
 
       MODULE
       {
@@ -496,7 +496,7 @@
     {
       name = LOX to GOX Converter
       desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
 
       MODULE
       {
@@ -588,7 +588,7 @@
     {
       name = LOX to GOX Converter
       desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
 
       MODULE
       {
@@ -683,7 +683,7 @@
     {
       name = LOX to GOX Converter
       desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
             
       MODULE
       {
@@ -776,7 +776,7 @@
     {
       name = LOX to GOX Converter
       desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
             
       MODULE
       {
@@ -942,7 +942,7 @@
     {
       name = N2 Pressure Control
       desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
 
       MODULE
       {
@@ -1075,7 +1075,7 @@
     {
       name = N2 Pressure Control
       desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
 
       MODULE
       {
@@ -1088,7 +1088,7 @@
     {
       name = LOX to GOX Converter
       desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
 
       MODULE
       {
@@ -1367,7 +1367,7 @@
     {
       name = N2 Pressure Control
       desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
       mass = 0.05 //FIXME
       cost = 25 //FIXME
 
@@ -1383,7 +1383,7 @@
     {
       name = O2 Pressure Control
       desc = Use <b>Oxygen</b> to maintain the internal atmosphere at a comfortable pressure.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
       mass = 0.01 //FIXME
       cost = 25 //FIXME
 
@@ -1431,7 +1431,7 @@
     {
       name = LOX to GOX Converter
       desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
       mass = 0.005 //FIXME
       cost = 20 //FIXME
 
@@ -1603,7 +1603,7 @@
     {
       name = LiOH Scrubber
       desc = A Lithium Hydroxide scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere. Its operational life <b>can</b> be increased by adding additional LiOH tanks.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
             
       MODULE
       {
@@ -1700,7 +1700,7 @@
     {
       name = LOX to GOX Converter
       desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
       MODULE
       {
         type = ProcessController
@@ -1719,7 +1719,7 @@
     {
       name = N2 Pressure Control
       desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-      tech = earlyLifeSupport
+      tech = rudimentaryLifeSupport
       MODULE
       {
         type = ProcessController


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RP-1/issues/2491

Rename:
```
titles:
Early Life Support and ISRU
Life Support and ISRU
Basic Life Support and ISRU
Improved Lift Support and ISRU

ids:
earlyLifeSupport
lifeSupportISRU
basicLifeSupport
improvedLifeSupport
```

to:
```
titles:
Rudimentary Life Support
Early Life Support
Basic Life Support
Improved Life Support

ids:
rudimentaryLifeSupport
earlyLifeSupport
basicLifeSupport
improvedLifeSupport
```

Relevant:
https://github.com/KSP-RO/RP-1/pull/2500