### PR TITLE
Nerf survival time without food/water

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -132,7 +132,7 @@ Supply
 		rate = 1.94976 // Based on RO-TACLS Profile (5.84928 per day)
 		interval = 28800.0 // 3 Meals per day
 		individuality = 0.00 // Everyone eats the same amount
-		degeneration = 0.0111111 // 90 meals, 30 days (taken from TACLS profile)
+		degeneration = 0.1111111 // 9 meals, 3 days
 		warning_message = #KERBALISM_food_warning //$ON_VESSEL$KERBAL is hungry
 		danger_message = #KERBALISM_food_danger //$ON_VESSEL$KERBAL is starving
 		fatal_message = #KERBALISM_food_fatal //$ON_VESSEL$KERBAL starved to death
@@ -145,7 +145,7 @@ Supply
 		output = WasteWater
 		rate = 0.774144 // Based on RO-TACLS Profile (3.87072 per day)
 		interval = 17280.0 // 5 drinks per-day
-		degeneration = 0.0666666 // 15 drinks, 3 days (taken from TACLS profile)
+		degeneration = 0.2000000 // 5 drinks, 1 day
 		individuality = 0.00 // Everyone uses the same amount
 		warning_threshold = 0.1
 		warning_message = #KERBALISM_water_warning //$ON_VESSEL$KERBAL is thirsty


### PR DESCRIPTION
Fix https://github.com/KSP-RO/ROKerbalism/issues/173
Nerf food survival time from 30 days to 3 days
Nerf water survival time from 3 days to 1 day

I decided to keep food higher than water, to emphasize the fact that food is more important. I would have put food at a week, but I really don't want people to send astronauts up for 6 days without any food at all. I feel like 3 days without food is the maximum where astronauts working 10 hour workdays would fail to continue working (and in space, that means you die).
1 day without water is pretty sensible as well, as a lot of body functions start failing after 1 day without water, and astronauts have a very strenuous work environment. (for anyone confused, remember that most of our water intake on earth is from water within food, but astronauts usually have dehydrated food)