### PR TITLE
Added water recycler config based on the one used in mir

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -329,6 +329,21 @@ Supply
 		dump = true
 	}
 
+	// Based on Mir water rcycling
+	// Created about half of the potable water on Mir
+	// source: "Experience in Development and Operation of a
+	// Regenerative System for Water Supply on Mir Space Station"
+	// convention: 1 capacity = enough to recycle output of 1 crew member
+	Process
+	{
+		name = Basic Water Recycler
+		modifier = _BasicWaterRecycler
+		input = ElectricCharge@0.0723 // 217 watts for 3 crew
+		input = WasteWater@0.00004458  // Matched to single crew output
+		output = Water@0.00002229 // 50% Water recovery
+		dump_valve = Water
+	}
+	
 	// Based on ISS Urine Reclamation
 	// convention: 1 capacity = enough to recycle output of 1 crew member
 	Process
@@ -1041,6 +1056,14 @@ Supply
 	MODULE
 	{
 		name = ProcessController
+		resource = _BasicWaterRecycler
+		title = Basic Water Recycler
+		capacity = 3
+		running = true
+	}
+	MODULE
+	{
+		name = ProcessController
 		resource = _WaterRecycler
 		title = Water Recycler
 		capacity = 3
@@ -1179,6 +1202,23 @@ Supply
 				id_value = _AirPump
 			}
 		}
+
+		SETUP
+		{
+			name = Basic Water Recycler
+			desc = Filter impurities out of <b>WasteWater</b>.
+			tech = longTermLifeSupport
+			mass = 0.452 //  
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _BasicWaterRecycler
+			}
+		}
+
 
 		SETUP
 		{
@@ -2357,6 +2397,17 @@ RESOURCE_DEFINITION
 @PART:HAS[@MODULE[ProcessController]:HAS[#resource[_WaterRecycler]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
 {
 	@tags ^=:$:, water recycler, water, wastewater, ammonia
+}
+
+RESOURCE_DEFINITION
+{
+  name = _BasicWaterRecycler
+  density = 0.0
+  isVisible = false
+}
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_BasicWaterRecycler]]]:NEEDS[ProfileRealismOverhaul]:LAST[Kerbalism]
+{
+	@tags ^=:$:, water recycler, water, wastewater
 }
 
 RESOURCE_DEFINITION


### PR DESCRIPTION
Source for mass, power, and efficiency is from "Experience in Development and Operation of a Regenerative System for Water Supply on Mir Space Station" by adding together the mass and power stats for the WRS-C, WRS-U, WRS-H, and WSS-ZV systems. The paper states that 55.5% of water came from this system, but I've rounded down that down to 50% just to make the number nicer.