### PR TITLE
Update drill rate to match cited source

### DIFF
--- a/GameData/KerbalismConfig/System/ISRU.cfg
+++ b/GameData/KerbalismConfig/System/ISRU.cfg
@@ -763,8 +763,8 @@
 		type = 0
 		resource = Regolith
 		min_abundance = 0.02
-		rate = 0.24166
-		ec_rate = 0.2 // FIXME
+		rate = 0.018125
+		ec_rate = 0.06 // FIXME
 	}
 	+MODULE[Harvester]:HAS[#title[Surface?Harvester]]
 	{
@@ -1000,8 +1000,8 @@
 		type = 0
 		resource = Regolith
 		min_abundance = 0.02
-		rate = 1.208333 // kerbalism-drill x 5
-		ec_rate = 0.8 // kerbalism-drill x 4
+		rate = 0.090625 // kerbalism-drill x 5
+		ec_rate = 0.320 // kerbalism-drill x 4
 	}
 
 	MODULE


### PR DESCRIPTION
The source for the drills (https://ntrs.nasa.gov/citations/20110016233) says that that it took 30W to gather 65.25kg in 30 minutes in the 2008 tethered competition. Scaling that to the 200W of the drill you get 241.66 g/s, way higher than the current 2000g/L * 0.000111 L/s = 0.222g/s. 

I've updated the drill rate of the small drill and large drill to match the numbers in the source.