### PR TITLE
Add VentureStar Configs

### DIFF
--- a/GameData/KerbalismConfig/Support/MK33.cfg
+++ b/GameData/KerbalismConfig/Support/MK33.cfg
@@ -1,0 +1,29 @@
+// --------------------------------------------------------
+// VentureStar
+// --------------------------------------------------------
+@PART[Mk33Cockpit]:NEEDS[RealismOverhaul,FeatureHabitat]:AFTER[zzzKerbalism]
+{
+    @MODULE[Habitat]
+    {
+        %volume = 32.0
+        %surface = 56.0
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _Scrubber
+        title = Scrubber
+        capacity = 8.0
+        running = true
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _PressureControlOxygen
+        title = O2 Pressure Control
+        capacity = 0.8 // (56 / 70)
+        running = true
+    }
+}

--- a/GameData/KerbalismConfig/Support/MK33.cfg
+++ b/GameData/KerbalismConfig/Support/MK33.cfg
@@ -21,9 +21,21 @@
     MODULE
     {
         name = ProcessController
-        resource = _PressureControlOxygen
-        title = O2 Pressure Control
+        resource = _PressureControl
+        title = N2 Pressure Control
         capacity = 0.8 // (56 / 70)
+        running = true
+    }
+}
+
+@PART[Mk33ProbeCore]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+    MODULE
+    {
+        name = ProcessController
+        resource = _FuelCellShuttle
+        title = Fuel Cell
+        capacity = 21 //Max continuous output matching Shuttle
         running = true
     }
 }


### PR DESCRIPTION
This PR adds configs for the MK-33 mod, with them specifically 'interpreted' as VentureStar. Presently, only for its cockpit and not for the pressurised payload bay.