### PR TITLE
Add Near Future Spacecraft Configs

### DIFF
--- a/GameData/KerbalismConfig/Support/NearFuture.cfg
+++ b/GameData/KerbalismConfig/Support/NearFuture.cfg
@@ -784,3 +784,183 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
 		}
 	}
 }
+
+// --------------------------------------------------------
+// Deep Space Command Module
+// --------------------------------------------------------
+@PART[command-mk3-9]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+    %MODULE[Habitat]
+    {
+        %volume = 11.0
+        %surface = 25.0
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _Scrubber
+        title = Scrubber
+        capacity = 2.0
+        running = true
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _PressureControl
+        title = N2 Pressure Control
+        capacity = 0.35
+        running = true
+    }
+}
+
+// --------------------------------------------------------
+// Blue Origin Space Vehicle
+// --------------------------------------------------------
+@PART[command-375-biconic-1]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+    %MODULE[Habitat]
+    {
+        %volume = 25.0
+        %surface = 40.0
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _Scrubber
+        title = Scrubber
+        capacity = 6.0
+        running = true
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _PressureControl
+        title = N2 Pressure Control
+        capacity = 0.57
+        running = true
+    }
+}
+
+// --------------------------------------------------------
+// Martian Excursion Module
+// --------------------------------------------------------
+@PART[command-mk4-1]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+    %MODULE[Habitat]
+    {
+        %volume = 30.0
+        %surface = 45.0
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _Scrubber
+        title = Scrubber
+        capacity = 7.0
+        running = true
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _PressureControl
+        title = N2 Pressure Control
+        capacity = 0.64
+        running = true
+    }
+}
+
+// --------------------------------------------------------
+// Inline Station Command
+// --------------------------------------------------------
+@PART[command-ppd-1]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+    %MODULE[Habitat]
+    {
+        %volume = 15.0
+        %surface = 30.0
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _Scrubber
+        title = Scrubber
+        capacity = 6.0
+        running = true
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _PressureControl
+        title = N2 Pressure Control
+        capacity = 0.43
+        running = true
+    }
+}
+
+// --------------------------------------------------------
+// Advanced Lightweight Capsule
+// --------------------------------------------------------
+@PART[command-125-1]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+    %MODULE[Habitat]
+    {
+        %volume = 3.0
+        %surface = 10.0
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _Scrubber
+        title = Scrubber
+        capacity = 2.0
+        running = true
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _PressureControl
+        title = N2 Pressure Control
+        capacity = 0.14
+        running = true
+    }
+}
+
+// --------------------------------------------------------
+// Flexcraft
+// --------------------------------------------------------
+@PART[command-125-orbit-1]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+    %MODULE[Habitat]
+    {
+        %volume = 2.0
+        %surface = 8.0
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _Scrubber
+        title = Scrubber
+        capacity = 1.0
+        running = true
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _PressureControl
+        title = N2 Pressure Control
+        capacity = 0.11
+        running = true
+    }
+}


### PR DESCRIPTION
This PR adds configs for some of the NF Spacecraft capsules. As some are redundant either with other parts of the mod or with already existing parts, I've only done a few of them. These are:

- A MEM
- Blue Origin's Space Vehicle
- NASA's Flexcraft
- A modern "Gemini" [1]

[1] - Because Rad proposed using a Gemini in 2015 in their save, which is a crime.