### PR TITLE
Adds the Altair/LSAM lunar lander from Aquila Lunar Lander mod 

### DIFF
--- a/GameData/KerbalismConfig/Support/Aquila_Altair.cfg
+++ b/GameData/KerbalismConfig/Support/Aquila_Altair.cfg
@@ -1,0 +1,56 @@
+// ----------------------------------------------------------------------------
+// Kerbalism Life Support & Scrubbing Profile
+// ----------------------------------------------------------------------------
+@PART[Altair_AscentStage]:AFTER[RealismOverhaul]:NEEDS[Kerbalism,RealismOverhaul]
+{
+    // High-efficiency CO2 scrubber and climate controls
+    MODULE
+    {
+        name = ProcessController
+        resource = _Scrubber
+        title = LiOH Scrubber
+        capacity = 4
+        running = true
+    }
+
+    MODULE
+    {
+        name = ProcessController
+        resource = _NonExecutable
+        title = Environmental Control
+        capacity = 4
+        running = true
+    }
+
+    // Cabin pressure & comfort
+    @MODULE[Habitat]
+    {
+        %volume = 28.0  // ~28 m^3 pressurized volume
+        %surface = 42.0
+        %pressurized = true
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Kerbalism Habitat & Air Pump Integration
+// ----------------------------------------------------------------------------
+@PART[Altair_Airlock]:AFTER[RealismOverhaul]:NEEDS[Kerbalism,RealismOverhaul]
+{
+    // Dedicated habitat volume for depress/repress cycles
+    @MODULE[Habitat]
+    {
+        %volume = 5.5     // ~5.5 m^3 pressurized airlock interior
+        %surface = 12.0
+        %pressurized = true
+    }
+
+    // High-capacity air pump to equalize or dump pressure during EVAs
+    MODULE
+    {
+        name = ProcessController
+        resource = _PressureControl
+        title = Airlock Pressure Equalizer
+        capacity = 2
+        running = false
+    }
+}

--- a/GameData/KerbalismConfig/Support/Aquila_Altair.cfg
+++ b/GameData/KerbalismConfig/Support/Aquila_Altair.cfg
@@ -22,6 +22,14 @@
         running = true
     }
 
+   MODULE
+{
+    name = ProcessController
+    resource = _VacuumScrubber
+    title = Vacuum Scrubber
+    capacity = 4
+    running = true
+}
     // Cabin pressure & comfort
     @MODULE[Habitat]
     {


### PR DESCRIPTION
this Pr brings the Altair lunar lander placed in 2018 where the first use of Altair as a landing system  was  planed 

<img width="480" height="416" alt="image" src="https://github.com/user-attachments/assets/1a4c2b76-187b-4e8d-a627-197a6bc9417d" />
